### PR TITLE
Allow alt="" or role="presentation"

### DIFF
--- a/docs/rules/img-uses-alt.md
+++ b/docs/rules/img-uses-alt.md
@@ -41,7 +41,7 @@ To tell this plugin to also check your `Image` element, specify this in your `.e
 }
 ```
 
-Note that passing props as spread attribute without `alt` explicitly defined will cause this rule to fail. Explicitly pass down `alt` prop for rule to pass. The prop must have an actual value to pass. Use `Image` component above as a reference for destructuring and applying the prop. **It is a good thing to explicitly pass props that you expect to be passed for self-documentation.**
+Note that passing props as spread attribute without `alt` explicitly defined will cause this rule to fail. Explicitly pass down `alt` prop or use `role="presentation"` for rule to pass. Use `Image` component above as a reference for destructuring and applying the prop. **It is a good thing to explicitly pass props that you expect to be passed for self-documentation.**
 
 ### Succeed
 ```jsx
@@ -49,7 +49,8 @@ Note that passing props as spread attribute without `alt` explicitly defined wil
 <img src="foo" alt={"Foo eating a sandwich."} />
 <img src="foo" alt={altText} />
 <img src="foo" alt={`${person} smiling`} />
-<img src="foo" alt="" role="presentation" /> <!-- Alt text can be an empty string if `role="presentation"` -->
+<img src="foo" alt="" />
+<img src="foo" role="presentation" />
 ```
 
 ### Fail

--- a/src/rules/img-uses-alt.js
+++ b/src/rules/img-uses-alt.js
@@ -22,39 +22,38 @@ module.exports = context => ({
       return;
     }
 
+    const hasRoleProp = hasAttribute(node.attributes, 'role');
+    const roleValue = getAttributeValue(hasRoleProp);
+    const isPresentation = hasRoleProp && roleValue.toLowerCase() === 'presentation';
+
+    if (isPresentation) {
+      return;
+    }
+
     const hasAltProp = hasAttribute(node.attributes, 'alt');
 
     // Missing alt prop error.
     if (!hasAltProp) {
       context.report({
         node,
-        message: `${nodeType} elements must have an alt prop.`
+        message: `${nodeType} elements must have an alt prop or use role="presentation".`
       });
       return;
     }
 
     // Check if alt prop is undefined.
-    const altProp = getAttributeValue(hasAltProp);
+    const altValue = getAttributeValue(hasAltProp);
 
-    // Check if alt prop is ""
-    const emptyAlt = hasAltProp && hasAltProp.value
-      && hasAltProp.value.type === 'Literal'
-      && hasAltProp.value.value === "";
-
-    const hasRoleProp = hasAttribute(node.attributes, 'role');
-    const roleProp = getAttributeValue(hasRoleProp);
-
-    // Allow altProp to be "" if `role="presentation"` is present.
-    const isValid = altProp || (emptyAlt && hasRoleProp && roleProp.toUpperCase() === 'PRESENTATION');
-
-    // Undefined alt prop error.
-    if (!isValid) {
-      context.report({
-        node,
-        message: `${nodeType} alt prop must have a value. You can set alt="" if role="presentation" is applied.`
-      });
+    if (altValue || altValue === '') {
       return;
     }
+
+    // Undefined alt prop error.
+    context.report({
+      node,
+      message:
+        `Invalid alt value for ${nodeType}. Use alt="" or role="presentation" for presentational images.`
+    });
   }
 });
 

--- a/src/util/getAttributeValue.js
+++ b/src/util/getAttributeValue.js
@@ -4,7 +4,7 @@ import buildTemplateLiteral from './buildTemplateLiteral';
 
 const getValue = value => {
   if (value.type === 'Literal') {
-    return value.value === "" ? undefined : value.value;
+    return value.value;
   } else if (value.type === 'Identifier') {
     return value.name === "" ? undefined : value.name;
   } else if (value.type === 'JSXElement') {
@@ -17,7 +17,7 @@ const getValue = value => {
 
   switch (type) {
     case 'Literal':
-      return obj.value === "" ? undefined : obj.value;
+      return obj.value;
     case 'TemplateLiteral':
       return buildTemplateLiteral(obj);
     case 'Identifier':

--- a/tests/src/rules/img-uses-alt.js
+++ b/tests/src/rules/img-uses-alt.js
@@ -26,12 +26,12 @@ const parserOptions = {
 const ruleTester = new RuleTester();
 
 const customMissingPropError = type => ({
-  message: `${type} elements must have an alt prop.`,
+  message: `${type} elements must have an alt prop or use role="presentation".`,
   type: 'JSXOpeningElement'
 });
 
 const customAltValueError = type => ({
-  message: `${type} alt prop must have a value. You can set alt="" if role="presentation" is applied.`,
+  message: `Invalid alt value for ${type}. Use alt="" or role="presentation" for presentational images.`,
   type: 'JSXOpeningElement'
 });
 
@@ -65,11 +65,15 @@ ruleTester.run('img-uses-alt', rule, {
     { code: '<img alt={foo.bar || ""} />', parserOptions },
     { code: '<img alt={bar() || ""} />', parserOptions },
     { code: '<img alt={foo.bar() || ""} />', parserOptions },
-    { code: '<img alt="" role="presentation" />', parserOptions }, // Allow alt to be undefined if role="presentation"
+    { code: '<img alt="" />', parserOptions },
+    { code: '<img alt=" " />', parserOptions },
+    { code: '<img alt="" role="presentation" />', parserOptions },
     { code: '<img alt="" role={`presentation`} />', parserOptions },
     { code: '<img alt="" role={"presentation"} />', parserOptions },
+    { code: '<img role="presentation" />;', parserOptions },
+    { code: '<img alt={undefined} role="presentation" />;', parserOptions },
+    { code: '<img alt role="presentation" />;', parserOptions },
     { code: '<img alt="this is lit..." role="presentation" />', parserOptions },
-    { code: '<img alt=" " />', parserOptions }, // For decorative images.
 
     // CUSTOM ELEMENT TESTS FOR STRING OPTION
     { code: '<Avatar alt="foo" />;', options: string, parserOptions },
@@ -86,6 +90,7 @@ ruleTester.run('img-uses-alt', rule, {
     { code: '<Avatar alt={() => void 0} />', options: string, parserOptions },
     { code: '<AVATAR />', options: string, parserOptions },
     { code: '<Avatar alt={alt || "foo" } />', options: string, parserOptions },
+    { code: '<Avatar alt="" />', options: string, parserOptions },
 
     // CUSTOM ELEMENT TESTS FOR ARRAY OPTION TESTS
     { code: '<Thumbnail alt="foo" />;', options: array, parserOptions },
@@ -123,10 +128,6 @@ ruleTester.run('img-uses-alt', rule, {
     { code: '<img alt />;', errors: [ expectedAltValueError ], parserOptions },
     { code: '<img alt={undefined} />;', errors: [ expectedAltValueError ], parserOptions },
     { code: '<img alt={`${undefined}`} />;', errors: [ expectedAltValueError ], parserOptions },
-    { code: '<img alt="" />;', errors: [ expectedAltValueError ], parserOptions },
-    { code: '<img role="presentation" />;', errors: [ expectedMissingPropError ], parserOptions },
-    { code: '<img alt={undefined} role="presentation" />;', errors: [ expectedAltValueError ], parserOptions },
-    { code: '<img alt role="presentation" />;', errors: [ expectedAltValueError ], parserOptions },
     { code: '<img src="xyz" />', errors: [ expectedMissingPropError ], parserOptions },
     { code: '<img {...this.props} />', errors: [ expectedMissingPropError ], parserOptions },
     { code: '<img alt={false || false} />', errors: [ expectedAltValueError ], parserOptions },
@@ -146,7 +147,6 @@ ruleTester.run('img-uses-alt', rule, {
       options: string,
       parserOptions
     },
-    { code: '<Avatar alt="" />;', errors: [ customAltValueError('Avatar') ], options: string, parserOptions },
     { code: '<Avatar src="xyz" />', errors: [ customMissingPropError('Avatar') ], options: string, parserOptions },
     { code: '<Avatar {...this.props} />', errors: [ customMissingPropError('Avatar') ], options: string, parserOptions },
 
@@ -165,7 +165,6 @@ ruleTester.run('img-uses-alt', rule, {
       options: array,
       parserOptions
     },
-    { code: '<Thumbnail alt="" />;', errors: [ customAltValueError('Thumbnail') ], options: array, parserOptions },
     { code: '<Thumbnail src="xyz" />', errors: [ customMissingPropError('Thumbnail') ], options: array, parserOptions },
     {
       code: '<Thumbnail {...this.props} />',
@@ -177,7 +176,6 @@ ruleTester.run('img-uses-alt', rule, {
     { code: '<Image alt />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
     { code: '<Image alt={undefined} />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
     { code: '<Image alt={`${undefined}`} />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
-    { code: '<Image alt="" />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
     { code: '<Image src="xyz" />', errors: [ customMissingPropError('Image') ], options: array, parserOptions },
     { code: '<Image {...this.props} />', errors: [ customMissingPropError('Image') ], options: array, parserOptions }
   ]

--- a/tests/src/rules/img-uses-alt.js
+++ b/tests/src/rules/img-uses-alt.js
@@ -25,18 +25,15 @@ const parserOptions = {
 
 const ruleTester = new RuleTester();
 
-const customMissingPropError = type => ({
+const missingPropError = type => ({
   message: `${type} elements must have an alt prop or use role="presentation".`,
   type: 'JSXOpeningElement'
 });
 
-const customAltValueError = type => ({
+const altValueError = type => ({
   message: `Invalid alt value for ${type}. Use alt="" or role="presentation" for presentational images.`,
   type: 'JSXOpeningElement'
 });
-
-const expectedMissingPropError = customMissingPropError('img');
-const expectedAltValueError = customAltValueError('img');
 
 const string = [ 'Avatar' ];
 const array = [ [ 'Thumbnail', 'Image' ] ];
@@ -124,59 +121,59 @@ ruleTester.run('img-uses-alt', rule, {
   ],
   invalid: [
     // DEFAULT ELEMENT 'img' TESTS
-    { code: '<img />;', errors: [ expectedMissingPropError ], parserOptions },
-    { code: '<img alt />;', errors: [ expectedAltValueError ], parserOptions },
-    { code: '<img alt={undefined} />;', errors: [ expectedAltValueError ], parserOptions },
-    { code: '<img alt={`${undefined}`} />;', errors: [ expectedAltValueError ], parserOptions },
-    { code: '<img src="xyz" />', errors: [ expectedMissingPropError ], parserOptions },
-    { code: '<img {...this.props} />', errors: [ expectedMissingPropError ], parserOptions },
-    { code: '<img alt={false || false} />', errors: [ expectedAltValueError ], parserOptions },
+    { code: '<img />;', errors: [ missingPropError('img') ], parserOptions },
+    { code: '<img alt />;', errors: [ altValueError('img') ], parserOptions },
+    { code: '<img alt={undefined} />;', errors: [ altValueError('img') ], parserOptions },
+    { code: '<img alt={`${undefined}`} />;', errors: [ altValueError('img') ], parserOptions },
+    { code: '<img src="xyz" />', errors: [ missingPropError('img') ], parserOptions },
+    { code: '<img {...this.props} />', errors: [ missingPropError('img') ], parserOptions },
+    { code: '<img alt={false || false} />', errors: [ altValueError('img') ], parserOptions },
 
     // CUSTOM ELEMENT TESTS FOR STRING OPTION
     {
       code: '<Avatar />;',
-      errors: [ customMissingPropError('Avatar') ],
+      errors: [ missingPropError('Avatar') ],
       options: string,
       parserOptions
     },
-    { code: '<Avatar alt />;', errors: [ customAltValueError('Avatar') ], options: string, parserOptions },
-    { code: '<Avatar alt={undefined} />;', errors: [ customAltValueError('Avatar') ], options: string, parserOptions },
+    { code: '<Avatar alt />;', errors: [ altValueError('Avatar') ], options: string, parserOptions },
+    { code: '<Avatar alt={undefined} />;', errors: [ altValueError('Avatar') ], options: string, parserOptions },
     {
       code: '<Avatar alt={`${undefined}`} />;',
-      errors: [ customAltValueError('Avatar') ],
+      errors: [ altValueError('Avatar') ],
       options: string,
       parserOptions
     },
-    { code: '<Avatar src="xyz" />', errors: [ customMissingPropError('Avatar') ], options: string, parserOptions },
-    { code: '<Avatar {...this.props} />', errors: [ customMissingPropError('Avatar') ], options: string, parserOptions },
+    { code: '<Avatar src="xyz" />', errors: [ missingPropError('Avatar') ], options: string, parserOptions },
+    { code: '<Avatar {...this.props} />', errors: [ missingPropError('Avatar') ], options: string, parserOptions },
 
     // CUSTOM ELEMENT TESTS FOR ARRAY OPTION TESTS
-    { code: '<Thumbnail />;', errors: [ customMissingPropError('Thumbnail') ], options: array, parserOptions },
-    { code: '<Thumbnail alt />;', errors: [ customAltValueError('Thumbnail') ], options: array, parserOptions },
+    { code: '<Thumbnail />;', errors: [ missingPropError('Thumbnail') ], options: array, parserOptions },
+    { code: '<Thumbnail alt />;', errors: [ altValueError('Thumbnail') ], options: array, parserOptions },
     {
       code: '<Thumbnail alt={undefined} />;',
-      errors: [ customAltValueError('Thumbnail') ],
+      errors: [ altValueError('Thumbnail') ],
       options: array,
       parserOptions
     },
     {
       code: '<Thumbnail alt={`${undefined}`} />;',
-      errors: [ customAltValueError('Thumbnail') ],
+      errors: [ altValueError('Thumbnail') ],
       options: array,
       parserOptions
     },
-    { code: '<Thumbnail src="xyz" />', errors: [ customMissingPropError('Thumbnail') ], options: array, parserOptions },
+    { code: '<Thumbnail src="xyz" />', errors: [ missingPropError('Thumbnail') ], options: array, parserOptions },
     {
       code: '<Thumbnail {...this.props} />',
-      errors: [ customMissingPropError('Thumbnail') ],
+      errors: [ missingPropError('Thumbnail') ],
       options: array,
       parserOptions
     },
-    { code: '<Image />;', errors: [ customMissingPropError('Image') ], options: array, parserOptions },
-    { code: '<Image alt />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
-    { code: '<Image alt={undefined} />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
-    { code: '<Image alt={`${undefined}`} />;', errors: [ customAltValueError('Image') ], options: array, parserOptions },
-    { code: '<Image src="xyz" />', errors: [ customMissingPropError('Image') ], options: array, parserOptions },
-    { code: '<Image {...this.props} />', errors: [ customMissingPropError('Image') ], options: array, parserOptions }
+    { code: '<Image />;', errors: [ missingPropError('Image') ], options: array, parserOptions },
+    { code: '<Image alt />;', errors: [ altValueError('Image') ], options: array, parserOptions },
+    { code: '<Image alt={undefined} />;', errors: [ altValueError('Image') ], options: array, parserOptions },
+    { code: '<Image alt={`${undefined}`} />;', errors: [ altValueError('Image') ], options: array, parserOptions },
+    { code: '<Image src="xyz" />', errors: [ missingPropError('Image') ], options: array, parserOptions },
+    { code: '<Image {...this.props} />', errors: [ missingPropError('Image') ], options: array, parserOptions }
   ]
 });


### PR DESCRIPTION
As we discussed on #6, it is okay to use `alt=""` without
`role="presentation"`. It is possible that we want to enforce no alt
prop if `role="presentation"` but I'll leave that for another time and
possibly a different rule.