### PR TITLE
Fix checks involving the tabIndex attribute that do not account for integer literals

### DIFF
--- a/src/rules/onclick-has-focus.js
+++ b/src/rules/onclick-has-focus.js
@@ -15,8 +15,8 @@ import getAttributeValue from '../util/getAttributeValue';
 // ----------------------------------------------------------------------------
 
 const errorMessage = 'Elements with onClick handlers must be focusable. ' +
-  'Either set the tabIndex property (usually 0), or use an element type which ' +
-  'is inherently focusable such as `button`.';
+  'Either set the tabIndex property to a valid value (usually 0), or use ' +
+  'an element type which is inherently focusable such as `button`.';
 
 module.exports = context => ({
   JSXOpeningElement: node => {
@@ -31,7 +31,7 @@ module.exports = context => ({
       return;
     } else if (isInteractiveElement(type, attributes)) {
       return;
-    } else if (getAttributeValue(getAttribute(attributes, 'tabIndex'))) {
+    } else if (!isNaN(Number(getAttributeValue(getAttribute(attributes, 'tabIndex'))))) {
       return;
     }
 

--- a/src/util/isInteractiveElement.js
+++ b/src/util/isInteractiveElement.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import getAttribute from './getAttribute';
-import { getLiteralAttributeValue } from './getAttributeValue';
+import getAttributeValue, { getLiteralAttributeValue } from './getAttributeValue';
 import DOMElements from './attributes/DOM';
 
 
@@ -9,9 +9,9 @@ import DOMElements from './attributes/DOM';
 // Map of tagNames to functions that return whether that element is interactive or not.
 const interactiveMap = {
   a: attributes => {
-    const href = getAttribute(attributes, 'href');
-    const tabIndex = getAttribute(attributes, 'tabIndex');
-    return (Boolean(href) || (!href && Boolean(tabIndex)));
+    const href = getAttributeValue(getAttribute(attributes, 'href'));
+    const tabIndex = getAttributeValue(getAttribute(attributes, 'tabIndex'));
+    return Boolean(href) || !isNaN(Number(tabIndex));
   },
   // This is same as `a` interactivity function
   area: attributes => interactiveMap.a(attributes),

--- a/tests/src/rules/onclick-has-focus.js
+++ b/tests/src/rules/onclick-has-focus.js
@@ -76,18 +76,18 @@ ruleTester.run('onclick-has-focus', rule, {
     { code: '<a onClick="showNextPage();">Next page</a>', errors: [ expectedError ], parserOptions },
     { code: '<a onClick="showNextPage();" tabIndex={undefined}>Next page</a>', errors: [ expectedError ], parserOptions },
     { code: '<a onClick="showNextPage();" tabIndex="bad">Next page</a>', errors: [ expectedError ], parserOptions },
+    { code: '<a onClick={() => void 0} />', errors: [ expectedError ], parserOptions },
     { code: '<area onClick={() => void 0} className="foo" />', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} tabIndex={undefined} />;', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} tabIndex="bad" />;', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} role={undefined} />;', errors: [ expectedError ], parserOptions },
+    { code: '<div onClick={() => void 0} aria-hidden={false} />;', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} {...props} />;', errors: [ expectedError ], parserOptions },
     { code: '<section onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
     { code: '<main onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
     { code: '<article onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
     { code: '<header onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
-    { code: '<footer onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
-    { code: '<div onClick={() => void 0} aria-hidden={false} />;', errors: [ expectedError ], parserOptions },
-    { code: '<a onClick={() => void 0} />', errors: [ expectedError ], parserOptions }
+    { code: '<footer onClick={() => void 0} />;', errors: [ expectedError ], parserOptions }
   ]
 });

--- a/tests/src/rules/onclick-has-focus.js
+++ b/tests/src/rules/onclick-has-focus.js
@@ -27,8 +27,8 @@ const ruleTester = new RuleTester();
 
 const  expectedError  = {
   message: 'Elements with onClick handlers must be focusable. ' +
-    'Either set the tabIndex property (usually 0), or use an element type which ' +
-    'is inherently focusable such as `button`.',
+    'Either set the tabIndex property to a valid value (usually 0), ' +
+    'or use an element type which is inherently focusable such as `button`.',
   type: 'JSXOpeningElement'
 };
 
@@ -46,6 +46,7 @@ ruleTester.run('onclick-has-focus', rule, {
     { code: '<div aria-hidden={2 >= 1} onClick={() => void 0} />', parserOptions },
     { code: '<input type="text" onClick={() => void 0} />', parserOptions },
     { code: '<input type="hidden" onClick={() => void 0} tabIndex="-1" />', parserOptions },
+    { code: '<input type="hidden" onClick={() => void 0} tabIndex={-1} />', parserOptions },
     { code: '<input onClick={() => void 0} />', parserOptions },
     { code: '<button onClick={() => void 0} className="foo" />', parserOptions },
     { code: '<option onClick={() => void 0} className="foo" />', parserOptions },
@@ -53,13 +54,15 @@ ruleTester.run('onclick-has-focus', rule, {
     { code: '<area href="#" onClick={() => void 0} className="foo" />', parserOptions },
     { code: '<textarea onClick={() => void 0} className="foo" />', parserOptions },
     { code: '<a tabIndex="0" onClick={() => void 0} />', parserOptions },
+    { code: '<a tabIndex={0} onClick={() => void 0} />', parserOptions },
     { code: '<a role="button" href="#" onClick={() => void 0} />', parserOptions },
     { code: '<a onClick={() => void 0} href="http://x.y.z" />', parserOptions },
     { code: '<a onClick={() => void 0} href="http://x.y.z" tabIndex="0" />', parserOptions },
+    { code: '<a onClick={() => void 0} href="http://x.y.z" tabIndex={0} />', parserOptions },
     { code: '<TestComponent onClick={doFoo} />', parserOptions },
     { code: '<input onClick={() => void 0} type="hidden" />;', parserOptions },
     { code: '<span onClick="doSomething();" tabIndex="0">Click me!</span>', parserOptions },
-    { code: '<span onClick="doSomething();" tabIndex="0">Click me!</span>', parserOptions },
+    { code: '<span onClick="doSomething();" tabIndex={0}>Click me!</span>', parserOptions },
     { code: '<span onClick="doSomething();" tabIndex="-1">Click me too!</span>', parserOptions },
     { code: '<a href="javascript:void(0);" onClick="doSomething();">Click ALL the things!</a>', parserOptions },
     { code: '<Foo.Bar onClick={() => void 0} aria-hidden={false} />;', parserOptions },
@@ -69,9 +72,14 @@ ruleTester.run('onclick-has-focus', rule, {
   invalid: [
     { code: '<span onClick="submitForm();">Submit</span>', errors: [ expectedError ], parserOptions },
     { code: '<span onClick="submitForm();" tabIndex={undefined}>Submit</span>', errors: [ expectedError ], parserOptions },
+    { code: '<span onClick="submitForm();" tabIndex="bad">Submit</span>', errors: [ expectedError ], parserOptions },
     { code: '<a onClick="showNextPage();">Next page</a>', errors: [ expectedError ], parserOptions },
+    { code: '<a onClick="showNextPage();" tabIndex={undefined}>Next page</a>', errors: [ expectedError ], parserOptions },
+    { code: '<a onClick="showNextPage();" tabIndex="bad">Next page</a>', errors: [ expectedError ], parserOptions },
     { code: '<area onClick={() => void 0} className="foo" />', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },
+    { code: '<div onClick={() => void 0} tabIndex={undefined} />;', errors: [ expectedError ], parserOptions },
+    { code: '<div onClick={() => void 0} tabIndex="bad" />;', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} role={undefined} />;', errors: [ expectedError ], parserOptions },
     { code: '<div onClick={() => void 0} {...props} />;', errors: [ expectedError ], parserOptions },
     { code: '<section onClick={() => void 0} />;', errors: [ expectedError ], parserOptions },


### PR DESCRIPTION
`tabIndex` values can be specified with both strings (ie. `tabIndex="0"`) or integers (ie. `tabIndex={0}`). Currently, some of the checks for `tabIndex` simply coerce the attribute's value into a boolean, so using `{0}` fails.

This change also enforces `tabIndex`s to have valid values in order for them to be considered present, rather than just checking for their existence.