### PR TITLE
[fix] Linter threw JS error when role is undefined

### DIFF
--- a/src/rules/img-has-alt.js
+++ b/src/rules/img-has-alt.js
@@ -24,7 +24,7 @@ module.exports = context => ({
 
     const roleProp = getAttribute(node.attributes, 'role');
     const roleValue = getAttributeValue(roleProp);
-    const isPresentation = roleProp && roleValue.toLowerCase() === 'presentation';
+    const isPresentation = roleProp && typeof roleValue === 'string' && roleValue.toLowerCase() === 'presentation';
 
     if (isPresentation) {
       return;

--- a/tests/src/rules/img-has-alt.js
+++ b/tests/src/rules/img-has-alt.js
@@ -129,6 +129,7 @@ ruleTester.run('img-has-alt', rule, {
     { code: '<img alt />;', errors: [ altValueError('img') ], parserOptions },
     { code: '<img alt={undefined} />;', errors: [ altValueError('img') ], parserOptions },
     { code: '<img src="xyz" />', errors: [ missingPropError('img') ], parserOptions },
+    { code: '<img role />', errors: [ missingPropError('img') ], parserOptions },
     { code: '<img {...this.props} />', errors: [ missingPropError('img') ], parserOptions },
     { code: '<img alt={false || false} />', errors: [ altValueError('img') ], parserOptions },
 


### PR DESCRIPTION
*To reproduce*

- Add `<img role />` to your JSX code
- Run the linter

*Result*

A JS error in the output

```
  1) img-has-alt invalid <img role />:
     TypeError: roleValue.toLowerCase is not a function
      at EventEmitter.JSXOpeningElement (img-has-alt.js:5:1)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/util/node-event-generator.js:40:22)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:607:23)
      at CommentEventGenerator.enterNode (node_modules/eslint/lib/util/comment-event-generator.js:97:23)
      at Controller.traverser.traverse.enter (node_modules/eslint/lib/eslint.js:905:36)
      at Controller.__execute (node_modules/estraverse/estraverse.js:397:31)
      at Controller.traverse (node_modules/estraverse/estraverse.js:501:28)
      at Controller.Traverser.controller.traverse (node_modules/eslint/lib/util/traverser.js:36:33)
      at EventEmitter.module.exports.api.verify (node_modules/eslint/lib/eslint.js:902:23)
      at runRuleForItem (node_modules/eslint/lib/testers/rule-tester.js:324:38)
      at testInvalidTemplate (node_modules/eslint/lib/testers/rule-tester.js:378:26)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:455:25)
```

*Expected*

A linter error in the output