### PR TITLE
Updating TABLIST role to include missing property

### DIFF
--- a/src/util/attributes/role.json
+++ b/src/util/attributes/role.json
@@ -2475,6 +2475,7 @@
     "abstract": false,
     "props": [
       "ARIA-LEVEL",
+      "ARIA-MULTISELECTABLE",
       "ARIA-ACTIVEDESCENDANT",
       "ARIA-ATOMIC",
       "ARIA-BUSY",


### PR DESCRIPTION
In other roles that allow `ARIA-MULTISELECTABLE`, it was listed near the top, after `ARIA-LEVEL`, so I tried to maintain the same ordering here.

fixes #82 