### PR TITLE
[no-static-element-interactions] List valid interactive elements in docs

### DIFF
--- a/docs/rules/no-static-element-interactions.md
+++ b/docs/rules/no-static-element-interactions.md
@@ -2,6 +2,8 @@
 
 Enforce non-interactive DOM elements have no interactive handlers. Static elements such as `<div>` and `<span>` should not have mouse/keyboard event listeners. Instead use something more semantic, such as a button or a link.
 
+Valid interactive elements are: `<a>`, `<area>`, `<button>`, `<input>`, `<option>`, `<select>`, or `<textarea>`.
+
 ## Rule details
 
 This rule takes no arguments.

--- a/docs/rules/no-static-element-interactions.md
+++ b/docs/rules/no-static-element-interactions.md
@@ -2,7 +2,13 @@
 
 Enforce non-interactive DOM elements have no interactive handlers. Static elements such as `<div>` and `<span>` should not have mouse/keyboard event listeners. Instead use something more semantic, such as a button or a link.
 
-Valid interactive elements are: `<a>`, `<area>`, `<button>`, `<input>`, `<option>`, `<select>`, or `<textarea>`.
+Valid interactive elements are:
+  - `<a>` elements with `href` or `tabIndex` props
+  - `<button>` elements
+  - `<input>` elements that are not `hidden`
+  - `<select>` and `<option>` elements
+  - `<textarea>` elements
+  - `<area>` elements
 
 ## Rule details
 


### PR DESCRIPTION
Updated documentation for `no-static-element-interactions` to list the interactive elements defined in `isInteractiveElement`.

The conversations in #91 seems to indicate it would be good to have an explicit list of these elements?