### PR TITLE
Fixing aria-invalid=true and aria-invalid=false validation

### DIFF
--- a/__tests__/src/rules/aria-proptypes-test.js
+++ b/__tests__/src/rules/aria-proptypes-test.js
@@ -123,6 +123,12 @@ ruleTester.run('aria-proptypes', rule, {
     { code: '<div aria-sort={`other`} />', parserOptions },
     { code: '<div aria-sort={foo} />', parserOptions },
     { code: '<div aria-sort={foo.bar} />', parserOptions },
+    { code: '<div aria-invalid={true} />', parserOptions },
+    { code: '<div aria-invalid="true" />', parserOptions },
+    { code: '<div aria-invalid={false} />', parserOptions },
+    { code: '<div aria-invalid="false" />', parserOptions },
+    { code: '<div aria-invalid="grammar" />', parserOptions },
+    { code: '<div aria-invalid="spelling" />', parserOptions },
 
     // TOKENLIST
     { code: '<div aria-relevant="additions" />', parserOptions },

--- a/src/rules/aria-proptypes.js
+++ b/src/rules/aria-proptypes.js
@@ -42,7 +42,7 @@ const validityCheck = (value, expectedType, permittedValues) => {
       // Booleans resolve to 0/1 values so hard check that it's not first.
       return typeof value !== 'boolean' && isNaN(Number(value)) === false;
     case 'token':
-      return typeof value === 'string' && permittedValues.indexOf(value.toLowerCase()) > -1;
+      return permittedValues.indexOf(typeof value === 'string' ? value.toLowerCase() : value) > -1;
     case 'tokenlist':
       return typeof value === 'string' &&
         value.split(' ').every(token => permittedValues.indexOf(token.toLowerCase()) > -1);

--- a/src/util/attributes/ARIA.json
+++ b/src/util/attributes/ARIA.json
@@ -47,7 +47,7 @@
   },
   "ARIA-INVALID": {
     "type": "token",
-    "values": [ "grammar", "false", "spelling", "true" ]
+    "values": [ "grammar", false, "spelling", true ]
   },
   "ARIA-LABEL": {
     "type": "string"


### PR DESCRIPTION
Fixes #125

aria-invalid's prop value was being converted to a boolean and hence failing the token check which always forced all tokens to be strings. This relaxes that constraint allowing non-string values and replacing the "true" and "false" aria-invalid tokens with `true` and `false` 