### PR TITLE
Only package lib and docs in the npm published module.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,4 @@
 node_modules
 reports
-npm-debug.log
 coverage
 .gitignore
-.DS_Store

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/evcohen/eslint-plugin-jsx-a11y"
   },
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "docs"
+  ],
   "scripts": {
     "build": "rimraf lib && babel src --out-dir lib && cp -R src/util/attributes lib/util/attributes",
     "prepublish": "npm run lint && npm run test && npm run build",


### PR DESCRIPTION
Responding to #156 

Sets files in the package.json to: lib, docs

I tested the package with `npm pack`. The resulting package contained the following:

```
CHANGELOG.md
LICENSE.md
README.md
docs
lib
package.json
```