### PR TITLE
Add a type keyword to the import of JSXOpeningElement in the rule template

### DIFF
--- a/scripts/boilerplate/rule.js
+++ b/scripts/boilerplate/rule.js
@@ -8,7 +8,7 @@ const ruleBoilerplate = (author, description) => `/**
 // Rule Definition
 // ----------------------------------------------------------------------------
 
-import { JSXOpeningElement } from 'ast-types-flow';
+import type { JSXOpeningElement } from 'ast-types-flow';
 import { generateObjSchema } from '../util/schemas';
 
 const errorMessage = '';


### PR DESCRIPTION
Found a small omission of `type` on an import statement in the rule boilerplate.