### PR TITLE
Ignore unneeded dot files in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .DS_Store
 .flowconfig
-.gitignore
 .travis.yml
 coverage
 flow

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,10 @@
-node_modules
-reports
-npm-debug.log
-coverage
-.gitignore
 .DS_Store
+.flowconfig
+.gitignore
+.travis.yml
+coverage
+flow
+node_modules
+npm-debug.log
+reports
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "rimraf lib && babel src --out-dir lib && cp -R src/util/attributes lib/util/attributes",
     "prepublish": "npm run lint && npm run flow && npm run test && npm run build",
     "coveralls": "cat ./reports/lcov.info | coveralls",
-    "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "flow": "if [ ! -e ./.flowconfig ]; then echo \"Could not find .flowconfig\"; else flow; test $? -eq 0 -o $? -eq 2; fi",
     "lint": "eslint  --config .eslintrc src __tests__",
     "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run lint:fix && npm run flow",


### PR DESCRIPTION
This one is for @ljharb =D

The .flowconfig file causes havoc when it's included in the built package.

BUT, without it, `npm test` fails.

So I updated the `flow` script to exit gracefully when `.flowconfig` isn't present. 

`.npmignore` is updated to exclude files that aren't necessary in the NPM package.