### PR TITLE
Update Fail example for anchor-has-content rule

### DIFF
--- a/docs/rules/anchor-has-content.md
+++ b/docs/rules/anchor-has-content.md
@@ -49,5 +49,5 @@ return (
 ### Fail
 ```jsx
 <a />
-<a><TextWrapper aria-hidden />
+<a><TextWrapper aria-hidden /></a>
 ```


### PR DESCRIPTION
closing `</a>` tag is missing