### PR TITLE
[WIP] - Implement global settings to map DOM elements to custom components

### DIFF
--- a/__tests__/src/rules/anchor-has-content-test.js
+++ b/__tests__/src/rules/anchor-has-content-test.js
@@ -10,8 +10,7 @@
 
 import { RuleTester } from 'eslint';
 import parserOptionsMapper from '../../__util__/parserOptionsMapper';
-import rule,
-  { determineChildType } from '../../../src/rules/anchor-has-content';
+import rule, { determineChildType } from '../../../src/rules/anchor-has-content';
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -27,9 +26,7 @@ const expectedError = {
 describe('determineChildType', () => {
   describe('default case', () => {
     it('should return false', () => {
-      expect(
-        determineChildType({}),
-      ).toBe(false);
+      expect(determineChildType({}, {})).toBe(false);
     });
   });
 });

--- a/__tests__/src/rules/heading-has-content-test.js
+++ b/__tests__/src/rules/heading-has-content-test.js
@@ -10,8 +10,7 @@
 
 import { RuleTester } from 'eslint';
 import parserOptionsMapper from '../../__util__/parserOptionsMapper';
-import rule,
-  { determineChildType } from '../../../src/rules/heading-has-content';
+import rule, { determineChildType } from '../../../src/rules/heading-has-content';
 
 // -----------------------------------------------------------------------------
 // Tests
@@ -27,12 +26,16 @@ const expectedError = {
 describe('determineChildType', () => {
   describe('default case', () => {
     it('should return false', () => {
-      expect(
-        determineChildType({}),
-      ).toBe(false);
+      expect(determineChildType({}, {})).toBe(false);
     });
   });
 });
+
+const customTypeSchema = [
+  {
+    components: ['Heading'],
+  },
+];
 
 ruleTester.run('heading-has-content', rule, {
   valid: [
@@ -49,10 +52,12 @@ ruleTester.run('heading-has-content', rule, {
     { code: '<h1>{foo.bar}</h1>' },
     { code: '<h1 dangerouslySetInnerHTML={{ __html: "foo" }} />' },
     { code: '<h1 children={children} />' },
+    { code: '<Heading>{foo}</Heading>', options: customTypeSchema },
   ].map(parserOptionsMapper),
   invalid: [
     { code: '<h1 />', errors: [expectedError] },
     { code: '<h1><Bar aria-hidden /></h1>', errors: [expectedError] },
     { code: '<h1>{undefined}</h1>', errors: [expectedError] },
+    { code: '<Heading>{undefined}</Heading>', options: customTypeSchema, errors: [expectedError] },
   ].map(parserOptionsMapper),
 });

--- a/__tests__/src/rules/href-no-hash-test.js
+++ b/__tests__/src/rules/href-no-hash-test.js
@@ -23,16 +23,22 @@ const expectedError = {
   type: 'JSXOpeningElement',
 };
 
-const components = [{
-  components: ['Anchor', 'Link'],
-}];
-const specialLink = [{
-  specialLink: ['hrefLeft', 'hrefRight'],
-}];
-const componentsAndSpecialLink = [{
-  components: ['Anchor'],
-  specialLink: ['hrefLeft'],
-}];
+const components = [
+  {
+    a: ['Anchor', 'Link'],
+  },
+];
+const specialLink = [
+  {
+    specialLink: ['hrefLeft', 'hrefRight'],
+  },
+];
+const componentsAndSpecialLink = [
+  {
+    a: ['Anchor'],
+    specialLink: ['hrefLeft'],
+  },
+];
 
 ruleTester.run('href-no-hash', rule, {
   valid: [
@@ -163,7 +169,11 @@ ruleTester.run('href-no-hash', rule, {
 
     // CUSTOM BOTH COMPONENTS AND SPECIALLINK TESTS
     { code: '<Anchor hrefLeft="#" />', errors: [expectedError], options: componentsAndSpecialLink },
-    { code: '<Anchor hrefLeft={"#"} />', errors: [expectedError], options: componentsAndSpecialLink },
+    {
+      code: '<Anchor hrefLeft={"#"} />',
+      errors: [expectedError],
+      options: componentsAndSpecialLink,
+    },
     {
       code: '<Anchor hrefLeft={`#${undefined}`} />',
       errors: [expectedError],

--- a/docs/rules/anchor-has-content.md
+++ b/docs/rules/anchor-has-content.md
@@ -13,13 +13,13 @@ This rule takes one optional object argument of type object:
 {
     "rules": {
         "jsx-a11y/anchor-has-content": [ 2, {
-            "components": [ "Anchor" ],
+            "a": [ "Anchor" ],
           }],
     }
 }
 ```
 
-For the `components` option, these strings determine which JSX elements (**always including** `<a>`) should be checked for having content. This is a good use case when you have a wrapper component that simply renders an `a` element (like in React):
+For the `a` option, these strings determine which JSX elements (**always including** `<a>`) should be checked for having content. This is a good use case when you have a wrapper component that simply renders an `a` element (like in React):
 
 ```js
 // Anchor.js

--- a/docs/rules/href-no-hash.md
+++ b/docs/rules/href-no-hash.md
@@ -10,14 +10,14 @@ This rule takes one optional object argument of type object:
 {
     "rules": {
         "jsx-a11y/href-no-hash": [ 2, {
-            "components": [ "Link" ],
+            "a": [ "Link" ],
             "specialLink": [ "hrefLeft", "hrefRight" ]
           }],
     }
 }
 ```
 
-For the `components` option, these strings determine which JSX elements (**always including** `<a>`) should be checked for the props designated in the `specialLink` options (**always including** `href`). This is a good use case when you have a wrapper component that simply renders an `a` element (like in React):
+For the `a` option, these strings determine which JSX elements (**always including** `<a>`) should be checked for the props designated in the `specialLink` options (**always including** `href`). This is a good use case when you have a wrapper component that simply renders an `a` element (like in React):
 
 ```js
 // Link.js

--- a/src/rules/anchor-has-content.js
+++ b/src/rules/anchor-has-content.js
@@ -9,21 +9,23 @@
 
 import { elementType, hasAnyProp } from 'jsx-ast-utils';
 import { arraySchema, generateObjSchema } from '../util/schemas';
+import { getCustomComponents, getDOMElementFromCustomComponent } from '../util/settings/resolve';
 import isHiddenFromScreenReader from '../util/isHiddenFromScreenReader';
 
 const errorMessage =
-    'Anchors must have content and the content must be accessible by a screen reader.';
+  'Anchors must have content and the content must be accessible by a screen reader.';
 
-const schema = generateObjSchema({ components: arraySchema });
+const schema = generateObjSchema({ a: arraySchema });
 
-const determineChildType = (child) => {
+const determineChildType = (context, child) => {
   switch (child.type) {
     case 'Literal':
       return Boolean(child.value);
     case 'JSXElement':
       return !isHiddenFromScreenReader(
-          elementType(child.openingElement),
-          child.openingElement.attributes);
+        getDOMElementFromCustomComponent(context, elementType(child.openingElement)),
+        child.openingElement.attributes,
+      );
     case 'JSXExpressionContainer':
       if (child.expression.type === 'Identifier') {
         return child.expression.name !== 'undefined';
@@ -43,19 +45,16 @@ module.exports = {
 
   create: context => ({
     JSXOpeningElement: (node) => {
-      const options = context.options[0] || {};
-      const componentOptions = options.components || [];
-      const typeCheck = ['a'].concat(componentOptions);
+      const { a: typeCheck } = getCustomComponents(context, 'a');
       const nodeType = elementType(node);
 
       // Only check anchor elements and custom types.
       if (typeCheck.indexOf(nodeType) === -1) {
         return;
       }
-      const isAccessible = node.parent.children.some(
-        determineChildType,
-      ) || hasAnyProp(node.attributes, ['dangerouslySetInnerHTML', 'children']);
-
+      const isAccessible =
+        node.parent.children.some(determineChildType.bind(this, context)) ||
+        hasAnyProp(node.attributes, ['dangerouslySetInnerHTML', 'children']);
 
       if (isAccessible) {
         return;

--- a/src/rules/aria-activedescendant-has-tabindex.js
+++ b/src/rules/aria-activedescendant-has-tabindex.js
@@ -6,6 +6,7 @@
 import { dom } from 'aria-query';
 import { getProp, elementType } from 'jsx-ast-utils';
 import { generateObjSchema } from '../util/schemas';
+import { getDOMElementFromCustomComponent } from '../util/settings/resolve';
 import getTabIndex from '../util/getTabIndex';
 import isInteractiveElement from '../util/isInteractiveElement';
 
@@ -13,8 +14,7 @@ import isInteractiveElement from '../util/isInteractiveElement';
 // Rule Definition
 // ----------------------------------------------------------------------------
 
-const errorMessage =
-  'An element that manages focus with `aria-activedescendant` must be tabbable';
+const errorMessage = 'An element that manages focus with `aria-activedescendant` must be tabbable';
 
 const schema = generateObjSchema();
 
@@ -34,7 +34,7 @@ module.exports = {
         return;
       }
 
-      const type = elementType(node);
+      const type = getDOMElementFromCustomComponent(context, elementType(node));
       // Do not test higher level JSX components, as we do not know what
       // low-level DOM element this maps to.
       if (domElements.indexOf(type) === -1) {
@@ -46,13 +46,7 @@ module.exports = {
       // unspecified allowing the inherent tabIndex to obtain or it must be
       // zero (allowing for positive, even though that is not ideal). It cannot
       // be given a negative value.
-      if (
-        isInteractiveElement(type, attributes)
-        && (
-          tabIndex === undefined
-          || tabIndex >= 0
-        )
-      ) {
+      if (isInteractiveElement(type, attributes) && (tabIndex === undefined || tabIndex >= 0)) {
         return;
       }
 

--- a/src/rules/aria-role.js
+++ b/src/rules/aria-role.js
@@ -10,6 +10,7 @@
 import { dom, roles } from 'aria-query';
 import { getLiteralPropValue, propName, elementType } from 'jsx-ast-utils';
 import { generateObjSchema } from '../util/schemas';
+import { getDOMElementFromCustomComponent } from '../util/settings/resolve';
 
 const errorMessage = 'Elements with ARIA roles must use a valid, non-abstract ARIA role.';
 
@@ -34,7 +35,7 @@ module.exports = {
       const ignoreNonDOM = !!options.ignoreNonDOM;
 
       if (ignoreNonDOM) {
-        const type = elementType(attribute.parent);
+        const type = getDOMElementFromCustomComponent(context, elementType(attribute.parent));
         if (!dom.get(type)) {
           return;
         }
@@ -44,22 +45,26 @@ module.exports = {
       const name = propName(attribute);
       const normalizedName = name ? name.toUpperCase() : '';
 
-      if (normalizedName !== 'ROLE') { return; }
+      if (normalizedName !== 'ROLE') {
+        return;
+      }
 
       const value = getLiteralPropValue(attribute);
 
       // If value is undefined, then the role attribute will be dropped in the DOM.
       // If value is null, then getLiteralAttributeValue is telling us that the
       // value isn't in the form of a literal.
-      if (value === undefined || value === null) { return; }
+      if (value === undefined || value === null) {
+        return;
+      }
 
       const normalizedValues = String(value).toLowerCase().split(' ');
-      const validRoles = [...roles.keys()].filter(
-        role => roles.get(role).abstract === false,
-      );
+      const validRoles = [...roles.keys()].filter(role => roles.get(role).abstract === false);
       const isValid = normalizedValues.every(val => validRoles.indexOf(val) > -1);
 
-      if (isValid === true) { return; }
+      if (isValid === true) {
+        return;
+      }
 
       context.report({
         node: attribute,

--- a/src/rules/aria-unsupported-elements.js
+++ b/src/rules/aria-unsupported-elements.js
@@ -8,12 +8,10 @@
 // Rule Definition
 // ----------------------------------------------------------------------------
 
-import {
-  aria,
-  dom,
-} from 'aria-query';
+import { aria, dom } from 'aria-query';
 import { elementType, propName } from 'jsx-ast-utils';
 import { generateObjSchema } from '../util/schemas';
+import { getDOMElementFromCustomComponent } from '../util/settings/resolve';
 
 const errorMessage = invalidProp =>
   `This element does not support ARIA roles, states and properties. \
@@ -29,11 +27,9 @@ module.exports = {
 
   create: context => ({
     JSXOpeningElement: (node) => {
-      const nodeType = elementType(node);
+      const nodeType = getDOMElementFromCustomComponent(context, elementType(node));
       const nodeAttrs = dom.get(nodeType) || {};
-      const {
-        reserved: isReservedNodeType = false,
-      } = nodeAttrs;
+      const { reserved: isReservedNodeType = false } = nodeAttrs;
 
       // If it's not reserved, then it can have aria-* roles, states, and properties
       if (isReservedNodeType === false) {

--- a/src/rules/click-events-have-key-events.js
+++ b/src/rules/click-events-have-key-events.js
@@ -7,16 +7,16 @@
 // Rule Definition
 // ----------------------------------------------------------------------------
 
-import {
-  dom,
-} from 'aria-query';
+import { dom } from 'aria-query';
 import { getProp, hasAnyProp, elementType } from 'jsx-ast-utils';
 import { generateObjSchema } from '../util/schemas';
+import { getDOMElementFromCustomComponent } from '../util/settings/resolve';
 import isHiddenFromScreenReader from '../util/isHiddenFromScreenReader';
 import isInteractiveElement from '../util/isInteractiveElement';
 
-const errorMessage = 'Visible, non-interactive elements with click handlers' +
-' must have at least one keyboard listener.';
+const errorMessage =
+  'Visible, non-interactive elements with click handlers' +
+  ' must have at least one keyboard listener.';
 
 const schema = generateObjSchema();
 const domElements = [...dom.keys()];
@@ -34,7 +34,7 @@ module.exports = {
         return;
       }
 
-      const type = elementType(node);
+      const type = getDOMElementFromCustomComponent(context, elementType(node));
       const requiredProps = ['onkeydown', 'onkeyup', 'onkeypress'];
 
       if (!domElements.includes(type)) {

--- a/src/rules/heading-has-content.js
+++ b/src/rules/heading-has-content.js
@@ -9,30 +9,25 @@
 
 import { elementType, hasAnyProp } from 'jsx-ast-utils';
 import { generateObjSchema, arraySchema } from '../util/schemas';
+import { getDOMElementFromCustomComponent, getCustomComponents } from '../util/settings/resolve';
 import isHiddenFromScreenReader from '../util/isHiddenFromScreenReader';
 
 const errorMessage =
   'Headings must have content and the content must be accessible by a screen reader.';
 
-const headings = [
-  'h1',
-  'h2',
-  'h3',
-  'h4',
-  'h5',
-  'h6',
-];
+const headings = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
 const schema = generateObjSchema({ components: arraySchema });
 
-const determineChildType = (child) => {
+const determineChildType = (context, child) => {
   switch (child.type) {
     case 'Literal':
       return Boolean(child.value);
     case 'JSXElement':
       return !isHiddenFromScreenReader(
-        elementType(child.openingElement),
-        child.openingElement.attributes);
+        getDOMElementFromCustomComponent(context, elementType(child.openingElement)),
+        child.openingElement.attributes,
+      );
     case 'JSXExpressionContainer':
       if (child.expression.type === 'Identifier') {
         return child.expression.name !== 'undefined';
@@ -52,18 +47,21 @@ module.exports = {
 
   create: context => ({
     JSXOpeningElement: (node) => {
-      const typeCheck = headings.concat(context.options[0]);
+      const customHeadingsMap = getCustomComponents(context, ...headings);
+      const customHeadings = headings.map(header => customHeadingsMap[header]);
+      const componentsOption = (context.options[0] && context.options[0].components) || [];
+      // Set containing all DOM h* elements and custom components that map to header DOM elements.
+      const typeCheck = new Set([].concat(...customHeadings, componentsOption));
       const nodeType = elementType(node);
 
       // Only check 'h*' elements and custom types.
-      if (typeCheck.indexOf(nodeType) === -1) {
+      if (!typeCheck.has(nodeType)) {
         return;
       }
 
-      const isAccessible = node.parent.children.some(
-        determineChildType,
-      ) || hasAnyProp(node.attributes, ['dangerouslySetInnerHTML', 'children']);
-
+      const isAccessible =
+        node.parent.children.some(determineChildType.bind(this, context)) ||
+        hasAnyProp(node.attributes, ['dangerouslySetInnerHTML', 'children']);
 
       if (isAccessible) {
         return;

--- a/src/rules/href-no-hash.js
+++ b/src/rules/href-no-hash.js
@@ -9,12 +9,13 @@
 
 import { getProp, getPropValue, elementType } from 'jsx-ast-utils';
 import { generateObjSchema, arraySchema } from '../util/schemas';
+import { getCustomComponents } from '../util/settings/resolve';
 
-const errorMessage = 'Links must not point to "#". ' +
-  'Use a more descriptive href or use a button instead.';
+const errorMessage =
+  'Links must not point to "#". Use a more descriptive href or use a button instead.';
 
 const schema = generateObjSchema({
-  components: arraySchema,
+  a: arraySchema,
   specialLink: arraySchema,
 });
 
@@ -27,8 +28,7 @@ module.exports = {
   create: context => ({
     JSXOpeningElement: (node) => {
       const options = context.options[0] || {};
-      const componentOptions = options.components || [];
-      const typesToValidate = ['a'].concat(componentOptions);
+      const typesToValidate = getCustomComponents(context, 'a').a;
       const nodeType = elementType(node);
 
       // Only check 'a' elements and custom types.

--- a/src/rules/html-has-lang.js
+++ b/src/rules/html-has-lang.js
@@ -9,6 +9,7 @@
 
 import { elementType, getProp, getPropValue } from 'jsx-ast-utils';
 import { generateObjSchema } from '../util/schemas';
+import { getDOMElementFromCustomComponent } from '../util/settings/resolve';
 
 const errorMessage = '<html> elements must have the lang prop.';
 
@@ -22,7 +23,7 @@ module.exports = {
 
   create: context => ({
     JSXOpeningElement: (node) => {
-      const type = elementType(node);
+      const type = getDOMElementFromCustomComponent(context, elementType(node));
 
       if (type && type !== 'html') {
         return;

--- a/src/util/isHiddenFromScreenReader.js
+++ b/src/util/isHiddenFromScreenReader.js
@@ -7,7 +7,7 @@ import { getProp, getPropValue, getLiteralPropValue } from 'jsx-ast-utils';
  *
  * <div aria-hidden /> is equivalent to the DOM as <div aria-hidden=true />.
  */
-const isHiddenFromScreenReader = (type, attributes) => {
+const isHiddenFromScreenReader = (type = '', attributes) => {
   if (type.toUpperCase() === 'INPUT') {
     const hidden = getLiteralPropValue(getProp(attributes, 'type'));
 

--- a/src/util/settings/defaultGlobalSettings.js
+++ b/src/util/settings/defaultGlobalSettings.js
@@ -1,0 +1,21 @@
+import { dom } from 'aria-query';
+
+const components = [...dom.keys()].reduce(
+  (elements, element) => ({
+    ...elements,
+    [element]: [],
+  }),
+  {},
+);
+
+export default {
+  settings: {
+    components,
+    props: {
+      // The casing to check for aria-* props on custom components.
+      aria: 'kebab',
+      // Role prop to check on custom components.
+      role: 'ariaRole',
+    },
+  },
+};

--- a/src/util/settings/resolve.js
+++ b/src/util/settings/resolve.js
@@ -1,0 +1,55 @@
+import { dom } from 'aria-query';
+import defaultGlobalSettings from './defaultGlobalSettings';
+
+function getGlobalSettings(context) {
+  const {
+    settings: { components: defaultComponents, props: defaultProps },
+  } = defaultGlobalSettings;
+  const globalSettings = context.settings || {};
+  const { components: globalComponents, props: globalProps } = globalSettings;
+  const components = {
+    ...defaultComponents,
+    ...globalComponents,
+  };
+  const props = {
+    ...defaultProps,
+    ...globalProps,
+  };
+  return {
+    components,
+    props,
+  };
+}
+
+function getRuleSettings(context) {
+  return context.options[0] || {};
+}
+
+/**
+ * Returns an object that maps DOM elements to the user-provided custom components.
+ */
+export function getCustomComponents(context, ...domElements) {
+  const globalComponentSettings = getGlobalSettings(context).components;
+  const ruleSettings = getRuleSettings(context); // { a: [ 'Link' ], div: [ 'MyDiv' ] }
+  return domElements.reduce((components, element) => {
+    const customComponentsForElement = ruleSettings[element] || globalComponentSettings[element];
+    return {
+      ...components,
+      // Always concat low-level DOM element
+      [element]: [element].concat(customComponentsForElement || []),
+    };
+  }, {});
+}
+
+/**
+ * Returns the DOM element that maps to a custom component.
+ * If it cannot be resolved, it returns the custom component.
+ */
+export function getDOMElementFromCustomComponent(context, component = '') {
+  const customComponents = getCustomComponents(context, ...dom.keys());
+  return (
+    Object.keys(customComponents).find(
+      element => customComponents[element].indexOf(component) > -1,
+    ) || component
+  );
+}


### PR DESCRIPTION
This is a work in progress, just wanted to post to see if everyone thought the direction for this looked OK. 

The goal here is to provide an API for devs to map DOM elements to their custom components for these rules to be checked on. These custom components should be the first wrapper around the DOM element and have a consistent API with the DOM element (i.e. if `a` maps to `Link`, `Link` needs to have `href` as a prop for `href-no-hash` to work correctly.) 

Rule configurations will override global settings (however, I can't think of a use case to override custom component naming on a per-rule level, maybe we should deprecate that in favor of bringing these to the global level).