### PR TITLE
[fix] - Polyfill missed Array.includes in test helper.

### DIFF
--- a/__mocks__/genInteractives.js
+++ b/__mocks__/genInteractives.js
@@ -3,6 +3,7 @@
  */
 
 import { dom, roles } from 'aria-query';
+import includes from 'array-includes';
 import JSXAttributeMock from './JSXAttributeMock';
 import JSXElementMock from './JSXElementMock';
 
@@ -127,14 +128,14 @@ const interactiveRoles = []
     'toolbar',
   )
   .filter(role => !roles.get(role).abstract)
-  .filter(role => roles.get(role).superClass.some(klasses => klasses.includes('widget')));
+  .filter(role => roles.get(role).superClass.some(klasses => includes(klasses, 'widget')));
 
 const nonInteractiveRoles = roleNames
   .filter(role => !roles.get(role).abstract)
-  .filter(role => !roles.get(role).superClass.some(klasses => klasses.includes('widget')))
+  .filter(role => !roles.get(role).superClass.some(klasses => includes(klasses, 'widget')))
   // 'toolbar' does not descend from widget, but it does support
   // aria-activedescendant, thus in practice we treat it as a widget.
-  .filter(role => !['toolbar'].includes(role));
+  .filter(role => !includes(['toolbar'], role));
 
 export function genElementSymbol(openingElement: Object) {
   return (


### PR DESCRIPTION
Forgot one use in a test helper, not sure how CI passed. It failed when I published `v5.0.1`. It shouldn't affect the fix in production, but running `npm test` inside the dependency directory will fail for certain node versions.

Issue first brought up in #230 