### PR TITLE
Bump aria-query to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "aria-query": "^0.5.0",
+    "aria-query": "^0.7.0",
     "array-includes": "^3.0.3",
     "ast-types-flow": "0.0.7",
     "axobject-query": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,9 +115,9 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.5.0.tgz#85e3152cd8cc5bab18dbed61cd9c4fce54fa79c3"
+aria-query@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.7.0.tgz#4af10a1e61573ddea0cf3b99b51c52c05b424d24"
   dependencies:
     ast-types-flow "0.0.7"
 


### PR DESCRIPTION
`aria-query` added some `aria-` attributes which were previously missing in
https://github.com/A11yance/aria-query/pull/7/files and this brings them to
`jsx-a11y`