### PR TITLE
Add npm package.json whitelist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.DS_Store
-.flowconfig
-.travis.yml
-coverage
-node_modules
-npm-debug.log
-reports
-yarn-error.log

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
     "url": "https://github.com/evcohen/eslint-plugin-jsx-a11y"
   },
   "main": "lib/index.js",
+  "files": [
+    "CHANGELOG.md",
+    "LICENSE.md",
+    "README.md",
+    "docs",
+    "lib"
+  ],
   "scripts": {
     "build": "rimraf lib && babel src --out-dir lib --copy-files",
     "coveralls": "cat ./reports/lcov.info | coveralls",


### PR DESCRIPTION
There seems to be no need to ship `src`, `flow`, or `scripts` to the user.

Fixes https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/249 (which currently breaks zero config CRA Flow integration).

Verified this works by removing all but these folders.

A whitelist is better than a blacklist in my experience because as project grows, people add infra-related folders to it.