### PR TITLE
Remove development artifacts from the NPM package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,7 +2,9 @@
 .flowconfig
 .travis.yml
 coverage
+flow
 node_modules
 npm-debug.log
+src
 reports
 yarn-error.log


### PR DESCRIPTION
Results in the following package

```
.npmignore
CHANGELOG.md
docs/
lib/
LICENSE.md
package.json
README.md
```