### PR TITLE
Prepend slash to top level dirs in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,10 @@
 .DS_Store
 .flowconfig
 .travis.yml
-coverage
-flow
-node_modules
+/coverage
+/flow
+/node_modules
 npm-debug.log
-src
-reports
+/src
+/reports
 yarn-error.log


### PR DESCRIPTION
"Lines prefixed with / will only match entries starting from the current location of that .npmignore. For example, /foo will match foo and not lib/foo, but foo will match both."

from https://github.com/npm/npm/wiki/Files-and-Ignores

I realized that the dirs in `.npmignore` should be prepended with `/` to indicate that they are top-level.

I noticed that the `src` subdir in `__tests__` was missing in the package. This change brings those back. `npm pack` produces:

```
__mocks__/
__tests__/
.babelrc
.eslintignore
.eslintrc
.npmignore
CHANGELOG.md
docs/
lib/
LICENSE.md
package.json
README.md
scripts/
```