### PR TITLE
Add reference to no-access-key

### DIFF
--- a/docs/rules/no-access-key.md
+++ b/docs/rules/no-access-key.md
@@ -2,6 +2,9 @@
 
 Enforce no accessKey prop on element. Access keys are HTML attributes that allow web developers to assign keyboard shortcuts to elements. Inconsistencies between keyboard shortcuts and keyboard commands used by screenreader and keyboard only users create accessibility complications so to avoid complications, access keys should not be used.
 
+### References
+1. [WebAIM](http://webaim.org/techniques/keyboard/accesskey#spec)
+
 ## Rule details
 
 This rule takes no arguments.


### PR DESCRIPTION
Add WebAIM resource with an explanation why `accesskey` attribute should be avoided.