### PR TITLE
Refined falsy check of the mixed typed baseAttr.value

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,6 @@
+[lints]
+sketchy-null-mixed=warn
+
 [ignore]
 <PROJECT_ROOT>/lib/.*
 <PROJECT_ROOT>/docs/.*

--- a/src/util/attributesComparator.js
+++ b/src/util/attributesComparator.js
@@ -29,12 +29,15 @@ function attributesComparator(
         }
         // Value exists and does not match.
         if (
+          /*
           baseAttr.value !== null &&
           baseAttr.value !== false &&
           baseAttr.value !== undefined &&
           baseAttr.value !== '' &&
           baseAttr.value !== 0 &&
           Object.prototype.hasOwnProperty.call(baseAttr, 'value') &&
+          */
+          baseAttr.value &&
           baseAttr.value !== getLiteralPropValue(attribute)
         ) {
           return false;

--- a/src/util/attributesComparator.js
+++ b/src/util/attributesComparator.js
@@ -32,6 +32,9 @@ function attributesComparator(
           baseAttr.value !== null &&
           baseAttr.value !== false &&
           baseAttr.value !== undefined &&
+          baseAttr.value !== '' &&
+          baseAttr.value !== 0 &&
+          baseAttr.value !== NaN &&
           Object.prototype.hasOwnProperty.call(baseAttr, "value") &&
           baseAttr.value !== getLiteralPropValue(attribute)
         ) {

--- a/src/util/attributesComparator.js
+++ b/src/util/attributesComparator.js
@@ -35,7 +35,7 @@ function attributesComparator(
           baseAttr.value !== '' &&
           baseAttr.value !== 0 &&
           baseAttr.value !== NaN &&
-          Object.prototype.hasOwnProperty.call(baseAttr, "value") &&
+          Object.prototype.hasOwnProperty.call(baseAttr, 'value') &&
           baseAttr.value !== getLiteralPropValue(attribute)
         ) {
           return false;

--- a/src/util/attributesComparator.js
+++ b/src/util/attributesComparator.js
@@ -29,8 +29,11 @@ function attributesComparator(
         }
         // Value exists and does not match.
         if (
-          baseAttr.value
-          && baseAttr.value !== getLiteralPropValue(attribute)
+          baseAttr.value !== null &&
+          baseAttr.value !== false &&
+          baseAttr.value !== undefined &&
+          Object.prototype.hasOwnProperty.call(baseAttr, "value") &&
+          baseAttr.value !== getLiteralPropValue(attribute)
         ) {
           return false;
         }

--- a/src/util/attributesComparator.js
+++ b/src/util/attributesComparator.js
@@ -34,7 +34,6 @@ function attributesComparator(
           baseAttr.value !== undefined &&
           baseAttr.value !== '' &&
           baseAttr.value !== 0 &&
-          baseAttr.value !== NaN &&
           Object.prototype.hasOwnProperty.call(baseAttr, 'value') &&
           baseAttr.value !== getLiteralPropValue(attribute)
         ) {


### PR DESCRIPTION
Refined the usage of the mixed typed value in the baseAttr object by explicitly wrtiting the expressions equivalent to falsy checking baseAttr.value