### PR TITLE
Bumping `jsx-ast-utils` to enable objectRestSpread

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@coursera/eslint-plugin-jsx-a11y",
+  "name": "eslint-plugin-jsx-a11y",
   "version": "6.0.3-0",
   "description": "Static AST checker for accessibility rules on JSX elements.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jsx-a11y",
-  "version": "6.0.3-0",
+  "version": "6.0.3",
   "description": "Static AST checker for accessibility rules on JSX elements.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "axobject-query": "^0.1.0",
     "damerau-levenshtein": "^1.0.0",
     "emoji-regex": "^6.1.0",
-    "jsx-ast-utils": "github:jnwng/jsx-ast-utils#jw/fix-spread-property"
+    "jsx-ast-utils": "^2.0.2"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jsx-a11y",
-  "version": "6.0.3",
+  "version": "6.0.2",
   "description": "Static AST checker for accessibility rules on JSX elements.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -60,14 +60,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@coursera/jsx-ast-utils": "2.0.2-0",
     "aria-query": "^0.7.0",
     "array-includes": "^3.0.3",
     "ast-types-flow": "0.0.7",
     "axobject-query": "^0.1.0",
     "damerau-levenshtein": "^1.0.0",
     "emoji-regex": "^6.1.0",
-    "jsx-ast-utils": "^2.0.0"
+    "jsx-ast-utils": "github:jnwng/jsx-ast-utils"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-plugin-jsx-a11y",
+  "name": "@coursera/eslint-plugin-jsx-a11y",
   "version": "6.0.2",
   "description": "Static AST checker for accessibility rules on JSX elements.",
   "keywords": [
@@ -60,6 +60,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@coursera/jsx-ast-utils": "2.0.2-0",
     "aria-query": "^0.7.0",
     "array-includes": "^3.0.3",
     "ast-types-flow": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/eslint-plugin-jsx-a11y",
-  "version": "6.0.2",
+  "version": "6.0.3-0",
   "description": "Static AST checker for accessibility rules on JSX elements.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "axobject-query": "^0.1.0",
     "damerau-levenshtein": "^1.0.0",
     "emoji-regex": "^6.1.0",
-    "jsx-ast-utils": "github:jnwng/jsx-ast-utils"
+    "jsx-ast-utils": "github:jnwng/jsx-ast-utils#jw/fix-spread-property"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4"


### PR DESCRIPTION
[Here's the requisite bump](https://github.com/evcohen/jsx-ast-utils/pull/60) in `jsx-ast-utils` to enable `objectRestSpread`. 

This should address #327 and close https://github.com/evcohen/eslint-plugin-jsx-a11y/pull/356 when published — for some reason the `package.json` showing for `eslint-plugin-jsx-a11y` in NPM has `jsx-ast-utils@^1.4.0` but should be `^2.0.0`.