### PR TITLE
Update axobject-query to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "aria-query": "^0.7.0",
     "array-includes": "^3.0.3",
     "ast-types-flow": "0.0.7",
-    "axobject-query": "^0.2.0",
+    "axobject-query": "^1.0.1",
     "damerau-levenshtein": "^1.0.0",
     "emoji-regex": "^6.1.0",
     "jsx-ast-utils": "^2.0.0"


### PR DESCRIPTION
axobject-query changed `label` from a structure element to a widget so that it can host interactivity. 

Closes #378.