### PR TITLE
Allow exception for implicit navigation role in no-redundant-roles rule

### DIFF
--- a/__tests__/src/rules/no-redundant-roles-test.js
+++ b/__tests__/src/rules/no-redundant-roles-test.js
@@ -10,7 +10,6 @@
 // -----------------------------------------------------------------------------
 
 import { RuleTester } from 'eslint';
-import { configs } from '../../../src';
 import parserOptionsMapper from '../../__util__/parserOptionsMapper';
 import rule from '../../../src/rules/no-redundant-roles';
 import ruleOptionsMapperFactory from '../../__util__/ruleOptionsMapperFactory';
@@ -41,26 +40,26 @@ const neverValid = [
   { code: '<button role={`${undefined}button`} />', errors: [expectedError('button', 'button')] },
 ];
 
-const recommendedOptions = (configs.recommended.rules[ruleName][1] || {});
-
 ruleTester.run(`${ruleName}:recommended`, rule, {
   valid: [
     ...alwaysValid,
     { code: '<nav role="navigation" />' },
   ]
-    .map(ruleOptionsMapperFactory(recommendedOptions))
     .map(parserOptionsMapper),
   invalid: neverValid
-    .map(ruleOptionsMapperFactory(recommendedOptions))
     .map(parserOptionsMapper),
 });
 
-ruleTester.run(`${ruleName}:strict`, rule, {
+const noNavExceptionsOptions = { nav: [] };
+
+ruleTester.run(`${ruleName}:recommended`, rule, {
   valid: alwaysValid
+    .map(ruleOptionsMapperFactory(noNavExceptionsOptions))
     .map(parserOptionsMapper),
   invalid: [
     ...neverValid,
     { code: '<nav role="navigation" />', errors: [expectedError('nav', 'navigation')] },
   ]
+    .map(ruleOptionsMapperFactory(noNavExceptionsOptions))
     .map(parserOptionsMapper),
 });

--- a/__tests__/src/rules/no-redundant-roles-test.js
+++ b/__tests__/src/rules/no-redundant-roles-test.js
@@ -10,7 +10,7 @@
 // -----------------------------------------------------------------------------
 
 import { RuleTester } from 'eslint';
-import { configs } from '../../../src/index';
+import { configs } from '../../../src';
 import parserOptionsMapper from '../../__util__/parserOptionsMapper';
 import rule from '../../../src/rules/no-redundant-roles';
 import ruleOptionsMapperFactory from '../../__util__/ruleOptionsMapperFactory';

--- a/docs/rules/no-redundant-roles.md
+++ b/docs/rules/no-redundant-roles.md
@@ -7,7 +7,7 @@ Some HTML elements have native semantics that are implemented by the browser. Th
 
 ## Rule details
 
-The recommended options for this rule allow an implicit role of `navigation` to be applied to a `nav` element as is [advised by w3](https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element). The options are provided as an object keyed by HTML element name; the value is an array of implicit ARIA roles that are allowed on the specified element.
+The default options for this rule allow an implicit role of `navigation` to be applied to a `nav` element as is [advised by w3](https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element). The options are provided as an object keyed by HTML element name; the value is an array of implicit ARIA roles that are allowed on the specified element.
 
 ```
 {
@@ -17,12 +17,6 @@ The recommended options for this rule allow an implicit role of `navigation` to 
     nav: ['navigation'],
   },
 }
-```
-
-Under the recommended options, the following code is valid. It would be invalid under the strict rules.
-
-```
-<nav role="navigation" />
 ```
 
 ### Succeed

--- a/docs/rules/no-redundant-roles.md
+++ b/docs/rules/no-redundant-roles.md
@@ -7,7 +7,23 @@ Some HTML elements have native semantics that are implemented by the browser. Th
 
 ## Rule details
 
-This rule takes no arguments.
+The recommended options for this rule allow an implicit role of `navigation` to be applied to a `nav` element as is [advised by w3](https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element). The options are provided as an object keyed by HTML element name; the value is an array of implicit ARIA roles that are allowed on the specified element.
+
+```
+{
+  'jsx-a11y/no-redundant-roles': [
+  'error',
+  {
+    nav: ['navigation'],
+  },
+}
+```
+
+Under the recommended options, the following code is valid. It would be invalid under the strict rules.
+
+```
+<nav role="navigation" />
+```
 
 ### Succeed
 ```jsx

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "axobject-query": "^1.0.1",
     "damerau-levenshtein": "^1.0.0",
     "emoji-regex": "^6.1.0",
+    "has": "^1.0.1",
     "jsx-ast-utils": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -137,7 +137,12 @@ module.exports = {
           },
         ],
         'jsx-a11y/no-onchange': 'error',
-        'jsx-a11y/no-redundant-roles': 'error',
+        'jsx-a11y/no-redundant-roles': [
+          'error',
+          {
+            nav: ['navigation'],
+          },
+        ],
         'jsx-a11y/no-static-element-interactions': [
           'error',
           {

--- a/src/index.js
+++ b/src/index.js
@@ -137,12 +137,7 @@ module.exports = {
           },
         ],
         'jsx-a11y/no-onchange': 'error',
-        'jsx-a11y/no-redundant-roles': [
-          'error',
-          {
-            nav: ['navigation'],
-          },
-        ],
+        'jsx-a11y/no-redundant-roles': 'error',
         'jsx-a11y/no-static-element-interactions': [
           'error',
           {

--- a/src/rules/no-interactive-element-to-noninteractive-role.js
+++ b/src/rules/no-interactive-element-to-noninteractive-role.js
@@ -20,6 +20,7 @@ import {
 } from 'jsx-ast-utils';
 import type { JSXIdentifier } from 'ast-types-flow';
 import includes from 'array-includes';
+import has from 'has';
 import type { ESLintContext } from '../../flow/eslint';
 import type { ESLintJSXAttribute } from '../../flow/eslint-jsx';
 import isInteractiveElement from '../util/isInteractiveElement';
@@ -69,10 +70,7 @@ module.exports = {
         // Allow overrides from rule configuration for specific elements and
         // roles.
         const allowedRoles = (options[0] || {});
-        if (
-          Object.prototype.hasOwnProperty.call(allowedRoles, type)
-          && includes(allowedRoles[type], role)
-        ) {
+        if (has(allowedRoles, type) && includes(allowedRoles[type], role)) {
           return;
         }
         if (

--- a/src/rules/no-noninteractive-element-interactions.js
+++ b/src/rules/no-noninteractive-element-interactions.js
@@ -20,6 +20,7 @@ import {
 } from 'jsx-ast-utils';
 import type { JSXOpeningElement } from 'ast-types-flow';
 import includes from 'array-includes';
+import has from 'has';
 import type { ESLintContext } from '../../flow/eslint';
 import { arraySchema, generateObjSchema } from '../util/schemas';
 import isAbstractRole from '../util/isAbstractRole';
@@ -61,7 +62,7 @@ module.exports = {
         const config = (options[0] || {});
         const interactiveProps = config.handlers || defaultInteractiveProps;
         // Allow overrides from rule configuration for specific elements and roles.
-        if (Object.prototype.hasOwnProperty.call(config, type)) {
+        if (has(config, type)) {
           attributes = attributes.filter(attr => !includes(config[type], propName(attr)));
         }
 

--- a/src/rules/no-noninteractive-element-to-interactive-role.js
+++ b/src/rules/no-noninteractive-element-to-interactive-role.js
@@ -20,6 +20,7 @@ import type {
   JSXIdentifier,
 } from 'ast-types-flow';
 import includes from 'array-includes';
+import has from 'has';
 import type { ESLintContext } from '../../flow/eslint';
 import type { ESLintJSXAttribute } from '../../flow/eslint-jsx';
 import getExplicitRole from '../util/getExplicitRole';
@@ -69,10 +70,7 @@ module.exports = {
         // Allow overrides from rule configuration for specific elements and
         // roles.
         const allowedRoles = (options[0] || {});
-        if (
-          Object.prototype.hasOwnProperty.call(allowedRoles, type)
-          && includes(allowedRoles[type], role)
-        ) {
+        if (has(allowedRoles, type) && includes(allowedRoles[type], role)) {
           return;
         }
         if (

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -11,6 +11,7 @@
 
 import { elementType } from 'jsx-ast-utils';
 import includes from 'array-includes';
+import has from 'has';
 import type { JSXOpeningElement } from 'ast-types-flow';
 import type { ESLintContext } from '../../flow/eslint';
 import { generateObjSchema } from '../util/schemas';
@@ -44,10 +45,7 @@ module.exports = {
 
         if (implicitRole === explicitRole) {
           const allowedRoles = (options[0] || {});
-          if (
-            Object.prototype.hasOwnProperty.call(allowedRoles, type) &&
-            includes(allowedRoles[type], implicitRole)
-          ) {
+          if (has(allowedRoles, type) && includes(allowedRoles[type], implicitRole)) {
             return;
           }
 

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -20,6 +20,8 @@ import getImplicitRole from '../util/getImplicitRole';
 const errorMessage = (element, implicitRole) =>
   `The element ${element} has an implicit role of ${implicitRole}. Defining this explicitly is redundant and should be avoided.`;
 
+const DEFAULT_ROLE_EXCEPTIONS = { nav: ['navigation'] };
+
 module.exports = {
   meta: {
     docs: {
@@ -50,8 +52,16 @@ module.exports = {
         }
 
         if (implicitRole === explicitRole) {
-          const allowedRoles = (options[0] || {});
-          if (has(allowedRoles, type) && includes(allowedRoles[type], implicitRole)) {
+          const allowedRedundantRoles = (options[0] || {});
+          let redundantRolesForElement;
+
+          if (has(allowedRedundantRoles, type)) {
+            redundantRolesForElement = allowedRedundantRoles[type];
+          } else {
+            redundantRolesForElement = DEFAULT_ROLE_EXCEPTIONS[type] || [];
+          }
+
+          if (includes(redundantRolesForElement, implicitRole)) {
             return;
           }
 

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -14,21 +14,27 @@ import includes from 'array-includes';
 import has from 'has';
 import type { JSXOpeningElement } from 'ast-types-flow';
 import type { ESLintContext } from '../../flow/eslint';
-import { generateObjSchema } from '../util/schemas';
 import getExplicitRole from '../util/getExplicitRole';
 import getImplicitRole from '../util/getImplicitRole';
 
 const errorMessage = (element, implicitRole) =>
   `The element ${element} has an implicit role of ${implicitRole}. Defining this explicitly is redundant and should be avoided.`;
 
-const schema = generateObjSchema();
-
 module.exports = {
   meta: {
     docs: {
       url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-redundant-roles.md',
     },
-    schema: [schema],
+    schema: [{
+      type: 'object',
+      additionalProperties: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        uniqueItems: true,
+      },
+    }],
   },
 
   create: (context: ESLintContext) => {


### PR DESCRIPTION
This change adds a configuration option that allows adding an exception for the `nav` element specifying a redundant and explicit `navigation` role as advised at https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element. This fixes https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/365.

I wasn't sure if the config should be flexible or not so I tried to follow the conventions around other rules. Most of the rules I looked at with options also used `flow`, it wasn't clear if I should use it in the rule so I went ahead and did, can certainly undo it if it's not desired, this is my first real time using it.