### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/src/rules/accessible-emoji.js
+++ b/src/rules/accessible-emoji.js
@@ -18,7 +18,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/accessible-emoji.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/alt-text.js
+++ b/src/rules/alt-text.js
@@ -152,7 +152,9 @@ const ruleByElement = {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/alt-text.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/anchor-has-content.js
+++ b/src/rules/anchor-has-content.js
@@ -19,7 +19,9 @@ const schema = generateObjSchema({ components: arraySchema });
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/anchor-has-content.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/anchor-is-valid.js
+++ b/src/rules/anchor-is-valid.js
@@ -33,7 +33,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/anchor-is-valid.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/aria-activedescendant-has-tabindex.js
+++ b/src/rules/aria-activedescendant-has-tabindex.js
@@ -22,7 +22,9 @@ const domElements = [...dom.keys()];
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/aria-activedescendant-has-tabindex.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/aria-props.js
+++ b/src/rules/aria-props.js
@@ -29,7 +29,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/aria-props.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/aria-proptypes.js
+++ b/src/rules/aria-proptypes.js
@@ -57,7 +57,9 @@ const schema = generateObjSchema();
 module.exports = {
   validityCheck,
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/aria-proptypes.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/aria-role.js
+++ b/src/rules/aria-role.js
@@ -22,7 +22,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/aria-role.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/aria-unsupported-elements.js
+++ b/src/rules/aria-unsupported-elements.js
@@ -23,7 +23,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/aria-unsupported-elements.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/click-events-have-key-events.js
+++ b/src/rules/click-events-have-key-events.js
@@ -25,7 +25,9 @@ const domElements = [...dom.keys()];
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/click-events-have-key-events.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/heading-has-content.js
+++ b/src/rules/heading-has-content.js
@@ -27,7 +27,9 @@ const schema = generateObjSchema({ components: arraySchema });
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/heading-has-content.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/html-has-lang.js
+++ b/src/rules/html-has-lang.js
@@ -16,7 +16,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/html-has-lang.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/iframe-has-title.js
+++ b/src/rules/iframe-has-title.js
@@ -16,7 +16,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/iframe-has-title.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/img-redundant-alt.js
+++ b/src/rules/img-redundant-alt.js
@@ -28,7 +28,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/img-redundant-alt.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/interactive-supports-focus.js
+++ b/src/rules/interactive-supports-focus.js
@@ -49,7 +49,9 @@ const interactiveProps = [
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/interactive-supports-focus.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/label-has-for.js
+++ b/src/rules/label-has-for.js
@@ -60,7 +60,9 @@ const isValid = (node, required, allowChildren) => {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/label-has-for.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/lang.js
+++ b/src/rules/lang.js
@@ -18,7 +18,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/lang.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/media-has-caption.js
+++ b/src/rules/media-has-caption.js
@@ -37,7 +37,9 @@ const isTrackType = (context, type) => {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/media-has-caption.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/mouse-events-have-key-events.js
+++ b/src/rules/mouse-events-have-key-events.js
@@ -18,7 +18,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/mouse-events-have-key-events.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-access-key.js
+++ b/src/rules/no-access-key.js
@@ -18,7 +18,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-access-key.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-autofocus.js
+++ b/src/rules/no-autofocus.js
@@ -23,7 +23,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-autofocus.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-distracting-elements.js
+++ b/src/rules/no-distracting-elements.js
@@ -25,7 +25,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-distracting-elements.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-interactive-element-to-noninteractive-role.js
+++ b/src/rules/no-interactive-element-to-noninteractive-role.js
@@ -33,7 +33,9 @@ const domElements = [...dom.keys()];
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-interactive-element-to-noninteractive-role.md',
+    },
     schema: [{
       type: 'object',
       additionalProperties: {

--- a/src/rules/no-noninteractive-element-interactions.js
+++ b/src/rules/no-noninteractive-element-interactions.js
@@ -46,7 +46,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-noninteractive-element-interactions.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-noninteractive-element-to-interactive-role.js
+++ b/src/rules/no-noninteractive-element-to-interactive-role.js
@@ -33,7 +33,9 @@ const domElements = [...dom.keys()];
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-noninteractive-element-to-interactive-role.md',
+    },
     schema: [{
       type: 'object',
       additionalProperties: {

--- a/src/rules/no-noninteractive-tabindex.js
+++ b/src/rules/no-noninteractive-tabindex.js
@@ -42,7 +42,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-noninteractive-tabindex.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-onchange.js
+++ b/src/rules/no-onchange.js
@@ -23,7 +23,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-onchange.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-redundant-roles.js
+++ b/src/rules/no-redundant-roles.js
@@ -20,7 +20,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-redundant-roles.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/no-static-element-interactions.js
+++ b/src/rules/no-static-element-interactions.js
@@ -45,7 +45,9 @@ const schema = generateObjSchema({
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/no-static-element-interactions.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/role-has-required-aria-props.js
+++ b/src/rules/role-has-required-aria-props.js
@@ -20,7 +20,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/role-has-required-aria-props.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/role-supports-aria-props.js
+++ b/src/rules/role-supports-aria-props.js
@@ -29,7 +29,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/role-supports-aria-props.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/scope.js
+++ b/src/rules/scope.js
@@ -17,7 +17,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/scope.md',
+    },
     schema: [schema],
   },
 

--- a/src/rules/tabindex-no-positive.js
+++ b/src/rules/tabindex-no-positive.js
@@ -16,7 +16,9 @@ const schema = generateObjSchema();
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: 'https://github.com/evcohen/eslint-plugin-jsx-a11y/tree/master/docs/rules/tabindex-no-positive.md',
+    },
     schema: [schema],
   },
 


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.