### PR TITLE
Update aria-query to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "aria-query": "^0.7.1",
+    "aria-query": "^2.0.0",
     "array-includes": "^3.0.3",
     "ast-types-flow": "^0.0.7",
     "axobject-query": "^1.0.2",


### PR DESCRIPTION
This PR allows us to use the updated aria attributes from ARIA 1.1 (see #196).

closes #412 