### PR TITLE
Fix heading-has-content to ignore headers that are aria-hidden

### DIFF
--- a/__tests__/src/rules/heading-has-content-test.js
+++ b/__tests__/src/rules/heading-has-content-test.js
@@ -38,6 +38,7 @@ ruleTester.run('heading-has-content', rule, {
     { code: '<h1>{foo.bar}</h1>' },
     { code: '<h1 dangerouslySetInnerHTML={{ __html: "foo" }} />' },
     { code: '<h1 children={children} />' },
+    { code: '<h1 aria-hidden />' },
   ].map(parserOptionsMapper),
   invalid: [
     { code: '<h1 />', errors: [expectedError] },

--- a/src/rules/heading-has-content.js
+++ b/src/rules/heading-has-content.js
@@ -10,6 +10,7 @@
 import { elementType } from 'jsx-ast-utils';
 import { generateObjSchema, arraySchema } from '../util/schemas';
 import hasAccessibleChild from '../util/hasAccessibleChild';
+import isHiddenFromScreenReader from '../util/isHiddenFromScreenReader';
 
 const errorMessage =
   'Headings must have content and the content must be accessible by a screen reader.';
@@ -42,6 +43,8 @@ module.exports = {
       if (typeCheck.indexOf(nodeType) === -1) {
         return;
       } else if (hasAccessibleChild(node.parent)) {
+        return;
+      } else if (isHiddenFromScreenReader(nodeType, node.attributes)) {
         return;
       }
 


### PR DESCRIPTION
Is it safe to assume that a heading that is `aria-hidden` is excused from the `heading-has-content` rule, since it will be skipped by screen readers?