### PR TITLE
added JSXText as a valid accessible child

### DIFF
--- a/__tests__/src/util/hasAccessibleChild-test.js
+++ b/__tests__/src/util/hasAccessibleChild-test.js
@@ -36,6 +36,15 @@ describe('hasAccessibleChild', () => {
       expect(hasAccessibleChild(element)).toBe(true);
     });
 
+    it('Returns true for JSXText Element', () => {
+      const child = {
+        type: 'JSXText',
+        value: 'foo',
+      };
+      const element = JSXElementMock('div', [], [child]);
+      expect(hasAccessibleChild(element)).toBe(true);
+    });
+
     it('Returns false for hidden child JSXElement', () => {
       const ariaHiddenAttr = JSXAttributeMock('aria-hidden', true);
       const child = JSXElementMock('div', [ariaHiddenAttr]);

--- a/src/util/hasAccessibleChild.js
+++ b/src/util/hasAccessibleChild.js
@@ -8,6 +8,7 @@ export default function hasAccessibleChild(node: JSXElement): boolean {
   return node.children.some((child) => {
     switch (child.type) {
       case 'Literal':
+      case 'JSXText':
         return Boolean(child.value);
       case 'JSXElement':
         return !isHiddenFromScreenReader(


### PR DESCRIPTION
we're using `eslint` and `eslint-plugin-jsx-a11y` here at Ticketmaster and our build failed the other day with this error:

```
{....}/components/sellFlow/index.js
  127:9  error  Headings must have content and the content must be accessible by a screen reader  jsx-a11y/heading-has-content

✖ 1 problem (1 error, 0 warnings)
```

but the incriminating line was this:

```jsx
<h4>Terms and Conditions</h4>
```

I managed to track it down to the fact that the text `Terms and Conditions` is defined as a child element of type `JSXText` and that is not accepted as a valid accessible child. I've added a test to simulate our scenario and added a minor fix. Thanks.