### PR TITLE
plural of emoji is emoji

### DIFF
--- a/docs/rules/accessible-emoji.md
+++ b/docs/rules/accessible-emoji.md
@@ -1,6 +1,6 @@
 # accessible-emoji
 
-Emojis have become a common way of communicating content to the end user. To a person using a screenreader, however, he/she may not be aware that this content is there at all. By wrapping the emoji in a `<span>`, giving it the `role="img"`, and providing a useful description in `aria-label`, the screenreader will treat the emoji as an image in the accessibility tree with an accessible name for the end user.
+Emoji have become a common way of communicating content to the end user. To a person using a screenreader, however, he/she may not be aware that this content is there at all. By wrapping the emoji in a `<span>`, giving it the `role="img"`, and providing a useful description in `aria-label`, the screenreader will treat the emoji as an image in the accessibility tree with an accessible name for the end user.
 
 #### Resources
 1. [Léonie Watson](http://tink.uk/accessible-emoji/)
@@ -13,7 +13,7 @@ This rule takes no arguments.
 ```jsx
 <span role="img" aria-label="Snowman">&#9731;</span>
 <span role="img" aria-label="Panda">🐼</span>
-<span role="img" aria-labelledby="panda1">🐼</span> 
+<span role="img" aria-labelledby="panda1">🐼</span>
 ```
 
 ### Fail


### PR DESCRIPTION
https://www.poynter.org/news/ap-stylebook-update-multiple-emoji-are-emoji

<span role="img" aria-label="Sheep Fish">🐑🐟</span>

modified:   docs/rules/accessible-emoji.md

Emojis have become a common way…
to
Emoji have become a common way…

Forgot to make a topic branch happy to redo if needed thanks!