### PR TITLE
Fix error when type attribute is truthy

### DIFF
--- a/__tests__/src/util/implicitRoles/input-test.js
+++ b/__tests__/src/util/implicitRoles/input-test.js
@@ -29,4 +29,7 @@ describe('isAbstractRole', () => {
   it('works for the default case', () => {
     expect(getImplicitRoleForInput([JSXAttributeMock('type', '')])).toBe('textbox');
   });
+  it('works for the true case', () => {
+    expect(getImplicitRoleForInput([JSXAttributeMock('type', true)])).toBe('textbox');
+  });
 });

--- a/__tests__/src/util/implicitRoles/menuitem-test.js
+++ b/__tests__/src/util/implicitRoles/menuitem-test.js
@@ -16,4 +16,7 @@ describe('isAbstractRole', () => {
   it('works for non-toolbars', () => {
     expect(getImplicitRoleForMenuitem([JSXAttributeMock('type', '')])).toBe('');
   });
+  it('works for the true case', () => {
+    expect(getImplicitRoleForMenuitem([JSXAttributeMock('type', true)])).toBe('');
+  });
 });

--- a/src/util/implicitRoles/input.js
+++ b/src/util/implicitRoles/input.js
@@ -9,7 +9,7 @@ export default function getImplicitRoleForInput(attributes) {
   if (type) {
     const value = getLiteralPropValue(type) || '';
 
-    switch (value.toUpperCase()) {
+    switch (typeof value === 'string' && value.toUpperCase()) {
       case 'BUTTON':
       case 'IMAGE':
       case 'RESET':

--- a/src/util/implicitRoles/menuitem.js
+++ b/src/util/implicitRoles/menuitem.js
@@ -9,7 +9,7 @@ export default function getImplicitRoleForMenuitem(attributes) {
   if (type) {
     const value = getLiteralPropValue(type) || '';
 
-    switch (value.toUpperCase()) {
+    switch (typeof value === 'string' && value.toUpperCase()) {
       case 'COMMAND':
         return 'menuitem';
       case 'CHECKBOX':


### PR DESCRIPTION
Fixes #400 

The null check was not sufficient as jsx can pass non string truthy values. For example:
```jsx
<input type />
```
