### PR TITLE
Special case for checkbox with role switch in role-has-required-aria-props

### DIFF
--- a/__tests__/src/rules/role-has-required-aria-props-test.js
+++ b/__tests__/src/rules/role-has-required-aria-props-test.js
@@ -55,6 +55,7 @@ ruleTester.run('role-has-required-aria-props', rule, {
     { code: '<div role={role || "foobar"} />' },
     { code: '<div role="row" />' },
     { code: '<span role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0"></span>' },
+    { code: '<input type="checkbox" role="switch" />' },
   ].concat(basicValidityTests).map(parserOptionsMapper),
 
   invalid: [

--- a/src/rules/role-has-required-aria-props.js
+++ b/src/rules/role-has-required-aria-props.js
@@ -58,6 +58,13 @@ module.exports = {
         .filter(val => [...roles.keys()].indexOf(val) > -1);
 
       validRoles.forEach((role) => {
+        // Handle special case for
+        // <input type="checkbox" role="switch" />
+        if (type === 'input' && role === 'switch'
+          && getLiteralPropValue(getProp(attribute.parent.attributes, 'type'))) {
+          return;
+        }
+
         const {
           requiredProps: requiredPropKeyValues,
         } = roles.get(role);

--- a/src/rules/role-has-required-aria-props.js
+++ b/src/rules/role-has-required-aria-props.js
@@ -53,18 +53,18 @@ module.exports = {
         return;
       }
 
+      // Handle special case for
+      // <input type="checkbox" role="switch" />
+      if (type === 'input' && value === 'switch'
+          && getLiteralPropValue(getProp(attribute.parent.attributes, 'type'))) {
+        return;
+      }
+
       const normalizedValues = String(value).toLowerCase().split(' ');
       const validRoles = normalizedValues
         .filter(val => [...roles.keys()].indexOf(val) > -1);
 
       validRoles.forEach((role) => {
-        // Handle special case for
-        // <input type="checkbox" role="switch" />
-        if (type === 'input' && role === 'switch'
-          && getLiteralPropValue(getProp(attribute.parent.attributes, 'type'))) {
-          return;
-        }
-
         const {
           requiredProps: requiredPropKeyValues,
         } = roles.get(role);


### PR DESCRIPTION
Fixes #484 

This passes the tests but I could use some context. Is it only this exact case that should pass?

Is it still valid with multiple roles?
```html
<input type="checkbox" role="switch checkbox" />
```