### PR TITLE
More easier `plugin:jsx-a11y/{recommended,strict}` configs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,9 @@ module.exports = {
   },
   configs: {
     recommended: {
+      plugins: [
+        'jsx-a11y',
+      ],
       parserOptions: {
         ecmaFeatures: {
           jsx: true,
@@ -160,6 +163,9 @@ module.exports = {
       },
     },
     strict: {
+      plugins: [
+        'jsx-a11y',
+      ],
       parserOptions: {
         ecmaFeatures: {
           jsx: true,


### PR DESCRIPTION
This makes setting `plugins` unnecessary when using `plugin:jsx-a11y/***` configs.

Before
------

```json
{
  "extends": ["plugin:jsx-a11y/recommended"],
  "plugins": ["jsx-a11y"]
}
```

After
-----

```json
{
  "extends": ["plugin:jsx-a11y/recommended"]
}
```

For example, `eslint-plugin-react` has a similar behavior:

https://github.com/yannickcr/eslint-plugin-react/blob/3008e85553b0ba66f396e2d6690eea420838bfec/index.js#L117