### PR TITLE
corrected no-noninteractive-element-to-interactive-role.md file

### DIFF
--- a/docs/rules/no-noninteractive-element-to-interactive-role.md
+++ b/docs/rules/no-noninteractive-element-to-interactive-role.md
@@ -50,14 +50,15 @@ The recommended options for this rule allow several common interactive roles to 
 ```
 {
   'no-noninteractive-element-to-interactive-role': [
-  'error',
-  {
-    ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
-    ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
-    li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
-    table: ['grid'],
-    td: ['gridcell'],
-  },
+    'error',
+    {
+      ul: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+      ol: ['listbox', 'menu', 'menubar', 'radiogroup', 'tablist', 'tree', 'treegrid'],
+      li: ['menuitem', 'option', 'row', 'tab', 'treeitem'],
+      table: ['grid'],
+      td: ['gridcell'],
+    },
+  ]
 }
 ```
 


### PR DESCRIPTION
Added missing square bracket in the example.