### PR TITLE
Disable jsx-a11y/label-has-for in recommended

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ module.exports = {
             ],
           },
         ],
-        'jsx-a11y/label-has-for': 'error',
+        'jsx-a11y/label-has-for': 'off',
         'jsx-a11y/label-has-associated-control': 'error',
         'jsx-a11y/media-has-caption': 'error',
         'jsx-a11y/mouse-events-have-key-events': 'error',


### PR DESCRIPTION
Since there's [issues with label-has-for](https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/455)  and it's [deprecated](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-for.md) , it shouldn't be a recommended rule, right?