### PR TITLE
Prevent Error when JSXSpreadAttribute is passed to isSemanticRoleElement

### DIFF
--- a/__tests__/src/rules/role-has-required-aria-props-test.js
+++ b/__tests__/src/rules/role-has-required-aria-props-test.js
@@ -55,6 +55,7 @@ ruleTester.run('role-has-required-aria-props', rule, {
     { code: '<div role={role || "foobar"} />' },
     { code: '<div role="row" />' },
     { code: '<span role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0"></span>' },
+    { code: '<input role="checkbox" aria-checked="false" aria-labelledby="foo" tabindex="0" {...props} type="checkbox" />' },
     { code: '<input type="checkbox" role="switch" />' },
   ].concat(basicValidityTests).map(parserOptionsMapper),
 

--- a/__tests__/src/util/isSemanticRoleElement-test.js
+++ b/__tests__/src/util/isSemanticRoleElement-test.js
@@ -27,4 +27,22 @@ describe('isSemanticRoleElement', () => {
       JSXAttributeMock('role', 'switch'),
     ])).toBe(false);
   });
+  it('should not throw on JSXSpreadAttribute', () => {
+    expect(() => {
+      isSemanticRoleElement('input', [
+        JSXAttributeMock('type', 'checkbox'),
+        JSXAttributeMock('role', 'checkbox'),
+        JSXAttributeMock('aria-checked', 'false'),
+        JSXAttributeMock('aria-labelledby', 'foo'),
+        JSXAttributeMock('tabindex', '0'),
+        {
+          type: 'JSXSpreadAttribute',
+          argument: {
+            type: 'Identifier',
+            name: 'props',
+          },
+        },
+      ]);
+    }).not.toThrow();
+  });
 });

--- a/src/util/isSemanticRoleElement.js
+++ b/src/util/isSemanticRoleElement.js
@@ -22,6 +22,9 @@ const isSemanticRoleElement = (
       && (concept.attributes || []).every(
         cAttr => attributes.some(
           (attr) => {
+            if (!attr.type || attr.type !== 'JSXAttribute') {
+              return false;
+            }
             const namesMatch = cAttr.name === propName(attr);
             let valuesMatch;
             if (cAttr.value !== undefined) {


### PR DESCRIPTION
This was an error I ran into when running v6.2.0 on the FB codebase. It took me a while to get the test case, but now that I have it, I put up the fix.

I included the CHANGELOG patch bump in this PR so that I can `npm version patch` it right after.