### PR TITLE
docs: add proper title to links to axe website for media-has-caption

### DIFF
--- a/docs/rules/media-has-caption.md
+++ b/docs/rules/media-has-caption.md
@@ -6,8 +6,8 @@ The captions should contain all important and relevant information to understand
 
 ### References
 
-  1.[aXe](https://dequeuniversity.com/rules/axe/2.1/audio-caption)
-  1.[aXe](https://dequeuniversity.com/rules/axe/2.1/video-caption)
+  1. [audio](https://dequeuniversity.com/rules/axe/2.1/audio-caption)
+  1. [video](https://dequeuniversity.com/rules/axe/2.1/video-caption)
 
 ## Rule details
 


### PR DESCRIPTION
while reading the docs for `media-has-caption`, was confused as to why there are two links that point to the same URL. Until you click on its not possible to know they point to different URL's.

This change makes it more obvious. Updated the text for the anchors. 