### PR TITLE
Fix typo: defintions > definitions

### DIFF
--- a/docs/rules/aria-role.md
+++ b/docs/rules/aria-role.md
@@ -1,6 +1,6 @@
 # aria-role
 
-Elements with ARIA roles must use a valid, non-abstract ARIA role. A reference to role defintions can be found at [WAI-ARIA](https://www.w3.org/TR/wai-aria/#role_definitions) site.
+Elements with ARIA roles must use a valid, non-abstract ARIA role. A reference to role definitions can be found at [WAI-ARIA](https://www.w3.org/TR/wai-aria/#role_definitions) site.
 
 [AX_ARIA_01](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_01)
 [DPUB-ARIA roles](https://www.w3.org/TR/dpub-aria-1.0/)


### PR DESCRIPTION
This corrects a minor spelling error I found within the documentation relating to the `aria-role` rule. 

Please let me know if there is more that you need from me to consider this file change. 

Thanks for the work y'all do on this eslint plugin for accessibility 🥇 