### PR TITLE
 Modified no-static-element-interactions to pass on non-literal roles.

### DIFF
--- a/__tests__/src/rules/no-static-element-interactions-test.js
+++ b/__tests__/src/rules/no-static-element-interactions-test.js
@@ -257,11 +257,12 @@ const alwaysValid = [
   { code: '<div onAnimationEnd={() => {}} />;' },
   { code: '<div onAnimationIteration={() => {}} />;' },
   { code: '<div onTransitionEnd={() => {}} />;' },
+  { code: '<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>' },
 ];
 
 const neverValid = [
   { code: '<div onClick={() => void 0} />;', errors: [expectedError] },
-  { code: '<div onClick={() => void 0} role={undefined} />;', errors: [expectedError] },
+  //  { code: '<div onClick={() => void 0} role={undefined} />;', errors: [expectedError] },
   { code: '<div onClick={() => void 0} {...props} />;', errors: [expectedError] },
   { code: '<div onKeyUp={() => void 0} aria-hidden={false} />;', errors: [expectedError] },
   /* Static elements; no inherent role */

--- a/__tests__/src/rules/no-static-element-interactions-test.js
+++ b/__tests__/src/rules/no-static-element-interactions-test.js
@@ -262,7 +262,7 @@ const alwaysValid = [
 
 const neverValid = [
   { code: '<div onClick={() => void 0} />;', errors: [expectedError] },
-  //  { code: '<div onClick={() => void 0} role={undefined} />;', errors: [expectedError] },
+  { code: '<div onClick={() => void 0} role={undefined} />;', errors: [expectedError] },
   { code: '<div onClick={() => void 0} {...props} />;', errors: [expectedError] },
   { code: '<div onKeyUp={() => void 0} aria-hidden={false} />;', errors: [expectedError] },
   /* Static elements; no inherent role */

--- a/__tests__/src/util/isNonLiteralProperty-test.js
+++ b/__tests__/src/util/isNonLiteralProperty-test.js
@@ -2,25 +2,33 @@
 import expect from 'expect';
 import toAST from 'to-ast';
 import isNonLiteralProperty from '../../../src/util/isNonLiteralProperty';
+import IdentifierMock from '../../../__mocks__/IdentifierMock';
 import JSXAttributeMock from '../../../__mocks__/JSXAttributeMock';
 import JSXExpressionContainerMock from '../../../__mocks__/JSXExpressionContainerMock';
 
 const theProp = 'theProp';
 
-describe('isNonLiteralRole', () => {
-  describe('elements without a role', () => {
+describe('isNonLiteralProperty', () => {
+  describe('elements without the property', () => {
     it('should not identify them as non-literal role elements', () => {
       expect(isNonLiteralProperty([], theProp)).toBe(false);
     });
   });
-  describe('elements with a literal role', () => {
+  describe('elements with a literal property', () => {
     it('should not identify them as non-literal role elements', () => {
       expect(isNonLiteralProperty([JSXAttributeMock(theProp, toAST('theRole'))], theProp)).toBe(false);
     });
   });
-  describe('elements with a expression role', () => {
+  describe('elements with a property of undefined', () => {
+    it('should not identify them as non-literal role elements', () => {
+      const undefinedExpression = IdentifierMock('undefined');
+      expect(isNonLiteralProperty([JSXAttributeMock(theProp, undefinedExpression)], theProp)).toBe(false);
+    });
+  });
+  describe('elements with a expression property', () => {
     it('should identify them as non-literal role elements', () => {
-      expect(isNonLiteralProperty([JSXAttributeMock(theProp, JSXExpressionContainerMock('expr'))], theProp)).toBe(true);
+      const identifierExpression = IdentifierMock('theIdentifier');
+      expect(isNonLiteralProperty([JSXAttributeMock(theProp, identifierExpression)], theProp)).toBe(true);
     });
   });
 });

--- a/__tests__/src/util/isNonLiteralProperty-test.js
+++ b/__tests__/src/util/isNonLiteralProperty-test.js
@@ -3,10 +3,13 @@ import expect from 'expect';
 import isNonLiteralProperty from '../../../src/util/isNonLiteralProperty';
 import IdentifierMock from '../../../__mocks__/IdentifierMock';
 import JSXAttributeMock from '../../../__mocks__/JSXAttributeMock';
+import JSXSpreadAttributeMock from '../../../__mocks__/JSXSpreadAttributeMock';
 import JSXTextMock from '../../../__mocks__/JSXTextMock';
 import LiteralMock from '../../../__mocks__/LiteralMock';
 
 const theProp = 'theProp';
+
+const spread = JSXSpreadAttributeMock('theSpread');
 
 describe('isNonLiteralProperty', () => {
   describe('elements without the property', () => {
@@ -15,8 +18,11 @@ describe('isNonLiteralProperty', () => {
     });
   });
   describe('elements with a literal property', () => {
-    it('should not identify them as non-literal role elements', () => {
+    it('should not identify them as non-literal role elements without spread operator', () => {
       expect(isNonLiteralProperty([JSXAttributeMock(theProp, LiteralMock('theRole'))], theProp)).toBe(false);
+    });
+    it('should not identify them as non-literal role elements with spread operator', () => {
+      expect(isNonLiteralProperty([spread, JSXAttributeMock(theProp, LiteralMock('theRole'))], theProp)).toBe(false);
     });
   });
   describe('elements with a JSXText property', () => {

--- a/__tests__/src/util/isNonLiteralProperty-test.js
+++ b/__tests__/src/util/isNonLiteralProperty-test.js
@@ -1,10 +1,10 @@
 /* eslint-env mocha */
 import expect from 'expect';
-import toAST from 'to-ast';
 import isNonLiteralProperty from '../../../src/util/isNonLiteralProperty';
 import IdentifierMock from '../../../__mocks__/IdentifierMock';
 import JSXAttributeMock from '../../../__mocks__/JSXAttributeMock';
-import JSXExpressionContainerMock from '../../../__mocks__/JSXExpressionContainerMock';
+import JSXTextMock from '../../../__mocks__/JSXTextMock';
+import LiteralMock from '../../../__mocks__/LiteralMock';
 
 const theProp = 'theProp';
 
@@ -16,7 +16,12 @@ describe('isNonLiteralProperty', () => {
   });
   describe('elements with a literal property', () => {
     it('should not identify them as non-literal role elements', () => {
-      expect(isNonLiteralProperty([JSXAttributeMock(theProp, toAST('theRole'))], theProp)).toBe(false);
+      expect(isNonLiteralProperty([JSXAttributeMock(theProp, LiteralMock('theRole'))], theProp)).toBe(false);
+    });
+  });
+  describe('elements with a JSXText property', () => {
+    it('should not identify them as non-literal role elements', () => {
+      expect(isNonLiteralProperty([JSXAttributeMock(theProp, JSXTextMock('theRole'))], theProp)).toBe(false);
     });
   });
   describe('elements with a property of undefined', () => {

--- a/__tests__/src/util/isNonLiteralProperty-test.js
+++ b/__tests__/src/util/isNonLiteralProperty-test.js
@@ -1,0 +1,26 @@
+/* eslint-env mocha */
+import expect from 'expect';
+import toAST from 'to-ast';
+import isNonLiteralProperty from '../../../src/util/isNonLiteralProperty';
+import JSXAttributeMock from '../../../__mocks__/JSXAttributeMock';
+import JSXExpressionContainerMock from '../../../__mocks__/JSXExpressionContainerMock';
+
+const theProp = 'theProp';
+
+describe('isNonLiteralRole', () => {
+  describe('elements without a role', () => {
+    it('should not identify them as non-literal role elements', () => {
+      expect(isNonLiteralProperty([], theProp)).toBe(false);
+    });
+  });
+  describe('elements with a literal role', () => {
+    it('should not identify them as non-literal role elements', () => {
+      expect(isNonLiteralProperty([JSXAttributeMock(theProp, toAST('theRole'))], theProp)).toBe(false);
+    });
+  });
+  describe('elements with a expression role', () => {
+    it('should identify them as non-literal role elements', () => {
+      expect(isNonLiteralProperty([JSXAttributeMock(theProp, JSXExpressionContainerMock('expr'))], theProp)).toBe(true);
+    });
+  });
+});

--- a/src/rules/no-static-element-interactions.js
+++ b/src/rules/no-static-element-interactions.js
@@ -27,6 +27,7 @@ import isInteractiveRole from '../util/isInteractiveRole';
 import isNonInteractiveElement from '../util/isNonInteractiveElement';
 import isNonInteractiveRole from '../util/isNonInteractiveRole';
 import isPresentationRole from '../util/isPresentationRole';
+import isNonLiteralProperty from '../util/isNonLiteralProperty';
 
 const errorMessage = 'Static HTML elements with event handlers require a role.';
 
@@ -87,6 +88,11 @@ module.exports = {
           || isAbstractRole(type, attributes)
         ) {
           // This rule has no opinion about abstract roles.
+          return;
+        }
+
+        if (isNonLiteralProperty(attributes, 'role')) {
+          // This rule has no opinion about non-literal roles.
           return;
         }
 

--- a/src/util/isNonLiteralProperty.js
+++ b/src/util/isNonLiteralProperty.js
@@ -26,11 +26,11 @@ const isNonLiteralProperty = (
   if (propValue.type === 'Literal') return false;
 
   if (propValue.type === 'JSXExpressionContainer') {
-    const {expression} = propValue;
+    const { expression } = propValue;
     console.log(JSON.stringify(expression));
     if (expression.type === 'Identifier' && expression.name === 'undefined') return false;
     if (expression.type === 'JSXText') return false;
-  } 
+  }
 
   return true;
 };

--- a/src/util/isNonLiteralProperty.js
+++ b/src/util/isNonLiteralProperty.js
@@ -1,0 +1,27 @@
+/**
+ * @flow
+ */
+
+import type { Node } from 'ast-types-flow';
+import { getProp } from 'jsx-ast-utils';
+
+/**
+ * Returns boolean indicating whether the given element has been specified with
+ * an AST node with a non-literal type.
+ *
+ * Returns true if the elements has a role and its value is not of a type Literal.
+ * Otherwise returns false.
+ */
+
+const isNonLiteralProperty = (
+  attributes: Array<Node>,
+  propName: string,
+): boolean => {
+  const prop = getProp(attributes, propName);
+  if (!prop) return false;
+
+  const roleValue = prop.value;
+  return !!roleValue && roleValue.type !== 'Literal';
+};
+
+export default isNonLiteralProperty;

--- a/src/util/isNonLiteralProperty.js
+++ b/src/util/isNonLiteralProperty.js
@@ -20,8 +20,18 @@ const isNonLiteralProperty = (
   const prop = getProp(attributes, propName);
   if (!prop) return false;
 
-  const roleValue = prop.value;
-  return !!roleValue && roleValue.type !== 'Literal';
+  const propValue = prop.value;
+  if (!propValue) return false;
+
+  if (propValue.type === 'Literal') return false;
+
+  if (propValue.type === 'JSXExpressionContainer') {
+    const {expression} = propValue;
+    console.log(JSON.stringify(expression));
+    if (expression.type === 'Identifier' && expression.name === 'undefined') return false;
+  } 
+
+  return true;
 };
 
 export default isNonLiteralProperty;

--- a/src/util/isNonLiteralProperty.js
+++ b/src/util/isNonLiteralProperty.js
@@ -27,7 +27,6 @@ const isNonLiteralProperty = (
 
   if (propValue.type === 'JSXExpressionContainer') {
     const { expression } = propValue;
-    console.log(JSON.stringify(expression));
     if (expression.type === 'Identifier' && expression.name === 'undefined') return false;
     if (expression.type === 'JSXText') return false;
   }

--- a/src/util/isNonLiteralProperty.js
+++ b/src/util/isNonLiteralProperty.js
@@ -29,6 +29,7 @@ const isNonLiteralProperty = (
     const {expression} = propValue;
     console.log(JSON.stringify(expression));
     if (expression.type === 'Identifier' && expression.name === 'undefined') return false;
+    if (expression.type === 'JSXText') return false;
   } 
 
   return true;


### PR DESCRIPTION
Addresses #245 .

Modified no-static-element-interactions rule to pass when role attribute is other than a literal value, a simple JSXtext element, or undefined.