### PR TITLE
Fixes “anchor-is-valid” false positive for hrefs starting with the word “javascript”

### DIFF
--- a/__tests__/src/rules/anchor-is-valid-test.js
+++ b/__tests__/src/rules/anchor-is-valid-test.js
@@ -89,6 +89,8 @@ ruleTester.run('anchor-is-valid', rule, {
     { code: '<a href="/foo" />' },
     { code: '<a href="https://foo.bar.com" />' },
     { code: '<div href="foo" />' },
+    { code: '<a href="javascript" />' },
+    { code: '<a href="javascriptFoo" />' },
     { code: '<a href={`#foo`}/>' },
     { code: '<a href={"foo"}/>' },
     { code: '<a href="#foo" />' },

--- a/__tests__/src/rules/anchor-is-valid-test.js
+++ b/__tests__/src/rules/anchor-is-valid-test.js
@@ -93,7 +93,11 @@ ruleTester.run('anchor-is-valid', rule, {
     { code: '<a href="javascriptFoo" />' },
     { code: '<a href={`#foo`}/>' },
     { code: '<a href={"foo"}/>' },
+    { code: '<a href={"javascript"}/>' },
+    { code: '<a href={`#javascript`}/>' },
     { code: '<a href="#foo" />' },
+    { code: '<a href="#javascript" />' },
+    { code: '<a href="#javascriptFoo" />' },
     { code: '<UX.Layout>test</UX.Layout>' },
     { code: '<a href={this} />' },
 

--- a/src/rules/anchor-is-valid.js
+++ b/src/rules/anchor-is-valid.js
@@ -97,7 +97,7 @@ module.exports = {
       const invalidHrefValues = values
         .filter(value => value !== undefined && value !== null)
         .filter(value => (typeof value === 'string' && (
-          !value.length || value === '#' || /^\W*?javascript/.test(value)
+          !value.length || value === '#' || /^\W*?javascript:/.test(value)
         )));
       if (invalidHrefValues.length !== 0) {
         // If an onClick is found it should be a button, otherwise it is an invalid link.


### PR DESCRIPTION
Fixes “anchor-is-valid” false positive for hrefs starting with the word “javascript”

Closes #579

Signed-off-by: Anthony Veaudry <anthony@veaudry.pro>