### PR TITLE
(fix) Template literals with undefined evaluate to the string undefined.

### DIFF
--- a/__tests__/src/rules/no-access-key-test.js
+++ b/__tests__/src/rules/no-access-key-test.js
@@ -28,8 +28,6 @@ ruleTester.run('no-access-key', rule, {
     { code: '<div />;' },
     { code: '<div {...props} />' },
     { code: '<div accessKey={undefined} />' },
-    { code: '<div accessKey={`${undefined}`} />' },
-    { code: '<div accessKey={`${undefined}${undefined}`} />' },
   ].map(parserOptionsMapper),
   invalid: [
     { code: '<div accesskey="h" />', errors: [expectedError] },
@@ -44,5 +42,7 @@ ruleTester.run('no-access-key', rule, {
     },
     { code: '<div accessKey={`This is ${bad}`} />', errors: [expectedError] },
     { code: '<div accessKey={accessKey} />', errors: [expectedError] },
+    { code: '<div accessKey={`${undefined}`} />', errors: [expectedError] },
+    { code: '<div accessKey={`${undefined}${undefined}`} />', errors: [expectedError] },
   ].map(parserOptionsMapper),
 });

--- a/__tests__/src/rules/no-redundant-roles-test.js
+++ b/__tests__/src/rules/no-redundant-roles-test.js
@@ -37,7 +37,6 @@ const alwaysValid = [
 const neverValid = [
   { code: '<button role="button" />', errors: [expectedError('button', 'button')] },
   { code: '<body role="DOCUMENT" />', errors: [expectedError('body', 'document')] },
-  { code: '<button role={`${undefined}button`} />', errors: [expectedError('button', 'button')] },
 ];
 
 ruleTester.run(`${ruleName}:recommended`, rule, {


### PR DESCRIPTION
**Problem**
In the most recent version of `jsx-ast-utils` we made a change to evaluate template literal strings with `undefined` and `null` to evaluate as the strings `"undefined"` and `"null"`. This change caused some tests to fail in this plugin.

**Solution**
Fix the tests to match the expected behavior of template literals.