### PR TITLE
Remove rootDir from Jest path configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
     ],
     "coverageDirectory": "reports",
     "roots": [
-      "<rootDir>/__tests__"
+      "__tests__"
     ],
     "testPathIgnorePatterns": [
-      "<rootDir>/__tests__/__util__"
+      "__tests__/__util__/"
     ],
     "testEnvironment": "node"
   },


### PR DESCRIPTION
Jest was failing to exclude the `__util__` directory from test runs.