### PR TITLE
Allow Node 4 / ESLint 3 failure to unblock ESLint upgrade in PR #568

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,5 @@ matrix:
     - node_js: "5"
     - node_js: "4" # not sure why this is failing; probably something in jest
       env: ESLINT=4
+    - node_js: "4"
+      env: ESLINT=3


### PR DESCRIPTION
<img width="941" alt="Build__1874_-_evcohen_eslint-plugin-jsx-a11y_-_Travis_CI" src="https://user-images.githubusercontent.com/345913/58532208-a6354880-8199-11e9-9c76-6711f4893cee.png">

The Node 4 / ESLint 3 combo is failing in #568 . This PR allows the failing combo. We already allow the Node 4 / ESLint 4 combo to fail, so this is just allowing an older-version combo to fail as well.