### PR TITLE
Allow select as a valid child of label.

### DIFF
--- a/src/rules/label-has-for.js
+++ b/src/rules/label-has-for.js
@@ -34,7 +34,7 @@ function validateNesting(node) {
   while (queue.length) {
     child = queue.shift();
     opener = child.openingElement;
-    if (child.type === 'JSXElement' && opener && (opener.name.name === 'input' || opener.name.name === 'textarea')) {
+    if (child.type === 'JSXElement' && opener && (opener.name.name === 'input' || opener.name.name === 'textarea' || opener.name.name === 'select')) {
       return true;
     }
     if (child.children) {


### PR DESCRIPTION
Currently an error is thrown for select within a label.

For example:

```
<label htmlFor="selectInput">
  Favorite ice creams
  <select id="selectInput" />
</label>
```

throws an error but should be okay.

