### PR TITLE
Update links to Deque University

### DIFF
--- a/docs/rules/alt-text.md
+++ b/docs/rules/alt-text.md
@@ -3,10 +3,10 @@
 Enforce that all elements that require alternative text have meaningful information to relay back to the end user. This is a critical component of accessibility for screenreader users in order for them to understand the content's purpose on the page. By default, this rule checks for alternative text on the following elements: `<img>`, `<area>`, `<input type="image">`, and `<object>`.
 
 #### Resources
-  1. [aXe object-alt](https://dequeuniversity.com/rules/axe/2.1/object-alt)
-  2. [aXe image-alt](https://dequeuniversity.com/rules/axe/2.1/image-alt)
-  3. [aXe input-image-alt](https://dequeuniversity.com/rules/axe/2.1/input-image-alt)
-  4. [aXe area-alt](https://dequeuniversity.com/rules/axe/2.1/area-alt)
+1. [axe-core, object-alt](https://dequeuniversity.com/rules/axe/3.2/object-alt)
+2. [axe-core, image-alt](https://dequeuniversity.com/rules/axe/3.2/image-alt)
+3. [axe-core, input-image-alt](https://dequeuniversity.com/rules/axe/3.2/input-image-alt)
+4. [axe-core, area-alt](https://dequeuniversity.com/rules/axe/3.2/area-alt)
 
 ## How to resolve
 ### `<img>`

--- a/docs/rules/anchor-has-content.md
+++ b/docs/rules/anchor-has-content.md
@@ -3,7 +3,7 @@
 Enforce that anchors have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the `aria-hidden` prop. Refer to the references to learn about why this is important.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/link-name)
+1. [axe-core, link-name](https://dequeuniversity.com/rules/axe/3.2/link-name)
 
 ## Rule details
 

--- a/docs/rules/heading-has-content.md
+++ b/docs/rules/heading-has-content.md
@@ -3,7 +3,7 @@
 Enforce that heading elements (`h1`, `h2`, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the `aria-hidden` prop. Refer to the references to learn about why this is important.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/empty-heading)
+1. [axe-core, empty-heading](https://dequeuniversity.com/rules/axe/3.2/empty-heading)
 
 ## Rule details
 

--- a/docs/rules/html-has-lang.md
+++ b/docs/rules/html-has-lang.md
@@ -3,7 +3,8 @@
 <html> elements must have the lang prop.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/html-lang)
+1. [axe-core, html-has-lang](https://dequeuniversity.com/rules/axe/3.2/html-has-lang)
+1. [axe-core, html-lang-valid](https://dequeuniversity.com/rules/axe/3.2/html-lang-valid)
 
 ## Rule details
 

--- a/docs/rules/iframe-has-title.md
+++ b/docs/rules/iframe-has-title.md
@@ -3,7 +3,7 @@
 `<iframe>` elements must have a unique title property to indicate its content to the user.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/frame-title)
+1. [axe-core, frame-title](https://dequeuniversity.com/rules/axe/3.2/frame-title)
 
 ## Rule details
 

--- a/docs/rules/lang.md
+++ b/docs/rules/lang.md
@@ -3,7 +3,7 @@
 The `lang` prop on the `<html>` element must have a valid value based on ISO country and language codes.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/valid-lang)
+1. [axe-core, valid-lang](https://dequeuniversity.com/rules/axe/3.2/valid-lang)
 2. [ISO Language Codes](http://www.w3schools.com/tags/ref_language_codes.asp)
 3. [ISO Country Codes](http://www.w3schools.com/tags/ref_country_codes.asp)
 

--- a/docs/rules/no-distracting-elements.md
+++ b/docs/rules/no-distracting-elements.md
@@ -3,8 +3,8 @@
 Enforces that no distracting elements are used. Elements that can be visually distracting can cause accessibility issues with visually impaired users. Such elements are most likely deprecated, and should be avoided. By default, the following elements are visually distracting: `<marquee>` and `<blink>`.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/marquee)
-2. [Deque University](https://dequeuniversity.com/rules/axe/1.1/blink)
+1. [axe-core, marquee](https://dequeuniversity.com/rules/axe/3.2/marquee)
+2. [axe-core, blink](https://dequeuniversity.com/rules/axe/3.2/blink)
 
 ## Rule details
 

--- a/docs/rules/scope.md
+++ b/docs/rules/scope.md
@@ -3,7 +3,7 @@
 The `scope` scope should be used only on `<th>` elements.
 
 #### References
-1. [Deque University](https://dequeuniversity.com/rules/axe/1.1/scope)
+1. [axe-core, scope](https://dequeuniversity.com/rules/axe/1.1/scope)
 
 ## Rule details
 


### PR DESCRIPTION
As the title says, update the links to Deque University to the latest version.

**note**: The `scope` rule was removed from axe-core some time ago, so it is not part of axe-core's 3.2 documentation.