### PR TITLE
Only run branch test coverage on the master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ script:
 after_success:
   - if [ "${TEST-}" = true ]; then npm run coveralls; fi
 sudo: false
+branches:
+  only:
+    - master
 env:
   global:
     - TEST=true


### PR DESCRIPTION
We're running Travis twice on each PR. We should only be running Travis on the `master` branch. The PR config will run Travis on PRs.