### PR TITLE
[583] Allow expression values in attributes by configuration

### DIFF
--- a/__tests__/src/rules/no-static-element-interactions-test.js
+++ b/__tests__/src/rules/no-static-element-interactions-test.js
@@ -258,7 +258,6 @@ const alwaysValid = [
   { code: '<div onAnimationEnd={() => {}} />;' },
   { code: '<div onAnimationIteration={() => {}} />;' },
   { code: '<div onTransitionEnd={() => {}} />;' },
-  { code: '<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>' },
 ];
 
 const neverValid = [
@@ -413,6 +412,9 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
     { code: '<div onAnimationEnd={() => {}} />;' },
     { code: '<div onAnimationIteration={() => {}} />;' },
     { code: '<div onTransitionEnd={() => {}} />;' },
+    // Expressions should pass in recommended mode
+    { code: '<div role={ROLE_BUTTON} onClick={() => {}} />;' },
+    { code: '<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>' },
   ]
     .map(ruleOptionsMapperFactory(recommendedOptions))
     .map(parserOptionsMapper),
@@ -446,5 +448,8 @@ ruleTester.run(`${ruleName}:strict`, rule, {
     { code: '<div onMouseMove={() => {}} />;', errors: [expectedError] },
     { code: '<div onMouseOut={() => {}} />;', errors: [expectedError] },
     { code: '<div onMouseOver={() => {}} />;', errors: [expectedError] },
+    // Expressions should fail in strict mode
+    { code: '<div role={ROLE_BUTTON} onClick={() => {}} />;', errors: [expectedError] },
+    { code: '<div  {...this.props} role={this.props.role} onKeyPress={e => this.handleKeyPress(e)}>{this.props.children}</div>', errors: [expectedError] },
   ].map(parserOptionsMapper),
 });

--- a/src/index.js
+++ b/src/index.js
@@ -177,6 +177,7 @@ module.exports = {
         'jsx-a11y/no-static-element-interactions': [
           'error',
           {
+            allowExpressionValues: true,
             handlers: [
               'onClick',
               'onMouseDown',

--- a/src/rules/no-static-element-interactions.js
+++ b/src/rules/no-static-element-interactions.js
@@ -26,8 +26,8 @@ import isInteractiveElement from '../util/isInteractiveElement';
 import isInteractiveRole from '../util/isInteractiveRole';
 import isNonInteractiveElement from '../util/isNonInteractiveElement';
 import isNonInteractiveRole from '../util/isNonInteractiveRole';
-import isPresentationRole from '../util/isPresentationRole';
 import isNonLiteralProperty from '../util/isNonLiteralProperty';
+import isPresentationRole from '../util/isPresentationRole';
 
 const errorMessage = 'Static HTML elements with event handlers require a role.';
 
@@ -55,11 +55,12 @@ module.exports = {
       JSXOpeningElement: (node: JSXOpeningElement) => {
         const { attributes } = node;
         const type = elementType(node);
-        const interactiveProps = options[0]
-          ? options[0].handlers
-          : defaultInteractiveProps;
+        const {
+          allowExpressionValues,
+          handlers = defaultInteractiveProps,
+        } = (options[0] || {});
 
-        const hasInteractiveProps = interactiveProps
+        const hasInteractiveProps = handlers
           .some(prop => (
             hasProp(attributes, prop)
             && getPropValue(getProp(attributes, prop)) != null
@@ -91,7 +92,10 @@ module.exports = {
           return;
         }
 
-        if (isNonLiteralProperty(attributes, 'role')) {
+        if (
+          allowExpressionValues === true
+          && isNonLiteralProperty(attributes, 'role')
+        ) {
           // This rule has no opinion about non-literal roles.
           return;
         }


### PR DESCRIPTION
Make the behavior that ignore expressions statements in the `role` attribute configurable.