### PR TITLE
Update jsx-ast-utils to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "damerau-levenshtein": "^1.0.4",
     "emoji-regex": "^7.0.2",
     "has": "^1.0.3",
-    "jsx-ast-utils": "^2.0.1"
+    "jsx-ast-utils": "^2.2.0"
   },
   "peerDependencies": {
     "eslint": "^3 || ^4 || ^5"


### PR DESCRIPTION
This should resolve issues with unknown AST nodes throwing errors.