### PR TITLE
Add @babel/cli to the dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jest": "jest --coverage __tests__/**/*"
   },
   "devDependencies": {
+    "@babel/cli": "^7.4.4",
     "@babel/core": "^7.0.0",
     "@babel/plugin-transform-flow-strip-types": "^7.2.3",
     "@babel/runtime": "^7.4.5",


### PR DESCRIPTION
Not sure why it needs to be added explicitly now, but it does.