### PR TITLE
fix(no-noninteractive-tabindex): should not flag `tooltip`

### DIFF
--- a/__tests__/src/rules/no-noninteractive-tabindex-test.js
+++ b/__tests__/src/rules/no-noninteractive-tabindex-test.js
@@ -35,6 +35,8 @@ const alwaysValid = [
   { code: '<div />' },
   { code: '<div tabIndex="-1" />' },
   { code: '<div role="button" tabIndex="0" />' },
+  { code: '<div role="tooltip" tabIndex="0" />' },
+  { code: '<div role="tooltip" tabIndex={0} />' },
   { code: '<div role="article" tabIndex="-1" />' },
   { code: '<article tabIndex="-1" />' },
 ];
@@ -49,6 +51,8 @@ const neverValid = [
 const recommendedOptions = (
   configs.recommended.rules[`jsx-a11y/${ruleName}`][1] || {}
 );
+
+const strictOptions = configs.strict.rules[`jsx-a11y/${ruleName}`][1] || {};
 
 ruleTester.run(`${ruleName}:recommended`, rule, {
   valid: [
@@ -69,11 +73,15 @@ ruleTester.run(`${ruleName}:recommended`, rule, {
 ruleTester.run(`${ruleName}:strict`, rule, {
   valid: [
     ...alwaysValid,
-  ].map(parserOptionsMapper),
+  ]
+    .map(ruleOptionsMapperFactory(strictOptions))
+    .map(parserOptionsMapper),
   invalid: [
     ...neverValid,
     { code: '<div role="tabpanel" tabIndex="0" />', errors: [expectedError] },
     // Expressions should fail in strict mode
     { code: '<div role={ROLE_BUTTON} onClick={() => {}} tabIndex="0" />;', errors: [expectedError] },
-  ].map(parserOptionsMapper),
+  ]
+    .map(ruleOptionsMapperFactory(strictOptions))
+    .map(parserOptionsMapper),
 });

--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,7 @@ module.exports = {
           'error',
           {
             tags: [],
-            roles: ['tabpanel'],
+            roles: ['tabpanel', 'tooltip'],
             allowExpressionValues: true,
           },
         ],
@@ -279,7 +279,12 @@ module.exports = {
           },
         ],
         'jsx-a11y/no-noninteractive-element-to-interactive-role': 'error',
-        'jsx-a11y/no-noninteractive-tabindex': 'error',
+        'jsx-a11y/no-noninteractive-tabindex': [
+          'error',
+          {
+            roles: ['tooltip'],
+          },
+        ],
         'jsx-a11y/no-onchange': 'error',
         'jsx-a11y/no-redundant-roles': 'error',
         'jsx-a11y/no-static-element-interactions': 'error',


### PR DESCRIPTION
Fixes issue #576 
Adds `tooltip` as allowed role and adds `alwaysValid` code examples for testing.

#hacktoberfest