### PR TITLE
fixing casing issue on aria-props

### DIFF
--- a/src/rules/aria-props.js
+++ b/src/rules/aria-props.js
@@ -38,14 +38,13 @@ module.exports = {
   create: context => ({
     JSXAttribute: (attribute) => {
       const name = propName(attribute);
-      const normalizedName = name.toLowerCase();
 
       // `aria` needs to be prefix of property.
-      if (normalizedName.indexOf('aria-') !== 0) {
+      if (name.indexOf('aria-') !== 0) {
         return;
       }
 
-      const isValid = ariaAttributes.indexOf(normalizedName) > -1;
+      const isValid = ariaAttributes.indexOf(name) > -1;
 
       if (isValid === false) {
         context.report({


### PR DESCRIPTION
I found a bug in my code where I accidentally capitalize the 'B' in aria-describedby :
`aria-describedBy`

I am hoping to remove the toLowerCase() in aria-props so that we can lint casing of aria props. 

<img width="870" alt="Screen Shot 2019-10-15 at 10 29 35 AM" src="https://user-images.githubusercontent.com/15275462/66854779-dad25280-ef36-11e9-96ff-85ea4f4a2a3a.png">
