### PR TITLE
fix: require missing 'autocomplete-valid' rule

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'aria-proptypes': require('./rules/aria-proptypes'),
     'aria-role': require('./rules/aria-role'),
     'aria-unsupported-elements': require('./rules/aria-unsupported-elements'),
+    'autocomplete-valid': require('./rules/autocomplete-valid'),
     'click-events-have-key-events': require('./rules/click-events-have-key-events'),
     'control-has-associated-label': require('./rules/control-has-associated-label'),
     'heading-has-content': require('./rules/heading-has-content'),


### PR DESCRIPTION
Recently I noticed this issue when I attempted to extend the recommended eslint-plugin-jsx-a11y configuration in a codebase (trimmed ESLint config file below).

```js
// .eslintrc.js
module.exports = {
  extends: [
    'eslint:recommended',
    'plugin:jsx-a11y/recommended'
  ],
}
```

After I did this I opened one of my React component files. The ESLint editor plugin in VS Code showed an error: `Definition for rule 'jsx-a11y/autocomplete-valid' was not found.eslint(jsx-a11y/autocomplete-valid)`

After checking the eslint-plugin-jsx-a11y `src/index.js` file I noticed that the 'autocomplete-valid' rule was not being required. This pull request should fix the issue.