### PR TITLE
Fix autocomplete-valid-test

### DIFF
--- a/__tests__/__util__/axeMapping.js
+++ b/__tests__/__util__/axeMapping.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/prefer-default-export, no-underscore-dangle */
 import * as axe from 'axe-core';
 
-export function axeFailMessage(checkId, data) {
-  return axe._audit.data.checks[checkId].messages.fail(data);
+export function axeFailMessage(checkId) {
+  return axe._audit.data.checks[checkId].messages.fail;
 }


### PR DESCRIPTION
`data` was never passed and `.fail` is not a function.

@WilcoFiers `._audit` looks like it's axe-core internal and it's the only reason `axe-core` is used in `eslint-plugin-jsx-a11y`.  Are there plans to make this part of the public axe-core API?