### PR TITLE
Pin axe-core version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "aria-query": "^4.0.1",
     "array-includes": "^3.0.3",
     "ast-types-flow": "^0.0.7",
-    "axe-core": "^3.4.0",
+    "axe-core": "=3.4.1",
     "axobject-query": "^2.1.1",
     "damerau-levenshtein": "^1.0.4",
     "emoji-regex": "^7.0.2",


### PR DESCRIPTION
Pin `axe-core` to v3.4.1 which is the latest version in which tests for
the 'autocomplete-valid' rule pass.

See [this PR](https://github.com/evcohen/eslint-plugin-jsx-a11y/pull/665) for more
information and small discussion.