### PR TITLE
[Tests] update axe-core

### DIFF
--- a/__tests__/__util__/axeMapping.js
+++ b/__tests__/__util__/axeMapping.js
@@ -2,5 +2,5 @@
 import * as axe from 'axe-core';
 
 export function axeFailMessage(checkId, data) {
-  return axe._audit.data.checks[checkId].messages.fail(data);
+  return axe.utils.getCheckMessage(checkId, 'fail', data);
 }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "aria-query": "^4.0.1",
     "array-includes": "^3.0.3",
     "ast-types-flow": "^0.0.7",
-    "axe-core": "=3.4.1",
+    "axe-core": "^3.5.2",
     "axobject-query": "^2.1.1",
     "damerau-levenshtein": "^1.0.4",
     "emoji-regex": "^7.0.2",


### PR DESCRIPTION
We released a new API method `axe.utils.getCheckMessage` that fixes the breaking change introduced in axe-core v3.5.1.

See https://github.com/dequelabs/axe-core/issues/2060